### PR TITLE
Bump version to 2.5.5 and update Tested up to 6.9.1

### DIFF
--- a/admin/class-admin-main.php
+++ b/admin/class-admin-main.php
@@ -47,7 +47,7 @@ class W4PL_Admin_Main {
 		global $post_ID;
 
 		$input_attr = sprintf(
-			'<input value="[postlist id=%d]" type="text" size="20" onfocus="this.select();" onclick="this.select();" readonly="readonly" />"',
+			'<input value="[postlist id=%d]" type="text" size="20" onfocus="this.select();" onclick="this.select();" readonly="readonly" />',
 			$post_ID
 		);
 

--- a/admin/class-admin-main.php
+++ b/admin/class-admin-main.php
@@ -47,7 +47,7 @@ class W4PL_Admin_Main {
 		global $post_ID;
 
 		$input_attr = sprintf(
-			'<input value="[postlist id=%d]" type="text" size="20" onfocus="this.select();" onclick="this.select();" readonly="readonly />"',
+			'<input value="[postlist id=%d]" type="text" size="20" onfocus="this.select();" onclick="this.select();" readonly="readonly" />"',
 			$post_ID
 		);
 

--- a/includes/class-w4-post-list.php
+++ b/includes/class-w4-post-list.php
@@ -29,7 +29,7 @@ final class W4_Post_List {
 	 *
 	 * @var string
 	 */
-	public $version = '2.5.4';
+	public $version = '2.5.5';
 
 	/**
 	 * This will hold current class instance

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "w4-post-list",
-	"version": "2.5.4",
+	"version": "2.5.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "w4-post-list",
-			"version": "2.5.4",
+			"version": "2.5.5",
 			"license": "GPL-3.0-or-later",
 			"devDependencies": {
 				"@wordpress/api-fetch": "^6.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "w4-post-list",
-	"version": "2.5.4",
+	"version": "2.5.5",
 	"description": "A WordPress Plugin for listing posts in some handy manner.",
 	"main": "Gruntfile.js",
 	"scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: sajib1223
 Tags: post, post list, custom post type, shortcode, media
 Requires at least: 5.8
-Tested up to: 6.9
+Tested up to: 6.9.1
 Requires PHP: 7.4
-Stable tag: 2.5.4
+Stable tag: 2.5.5
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -112,6 +112,8 @@ Each list have a unique id. Display a list by using `[postlist id="LIST_ID"]`.
 3. Preview 2
 
 == Changelog ==
+= 2.5.5 =
+* Tested up to WordPress 6.9.1.
 = 2.5.4 =
 * Fix: Sanitized media image width and height attributes - https://github.com/w4devInc/w4-post-list/issues/64.
 = 2.5.3 =
@@ -123,6 +125,8 @@ Each list have a unique id. Display a list by using `[postlist id="LIST_ID"]`.
 [See changelog of all versions](https://raw.githubusercontent.com/w4devInc/w4-post-list/master/CHANGELOG.txt).
 
 == Upgrade Notice ==
+= 2.5.5 =
+* Tested up to WordPress 6.9.1.
 = 2.5.4 =
 * Fix: Sanitized media image width and height attributes - https://github.com/w4devInc/w4-post-list/issues/64.
 = 2.5.3 =

--- a/w4-post-list.php
+++ b/w4-post-list.php
@@ -5,7 +5,7 @@
  * Description: This plugin lets you create a list of - Posts, Terms, Users, Terms + Posts and Users + Posts. Outputs are completely customizable using Shortcode, HTML & CSS. Read documentation plugin usage.
  * Version: 2.5.5
  * Requires at least: 5.8
- * Requires PHP: 5.7
+ * Requires PHP: 7.4
  * Author: Shazzad Hossain Khan
  * Author URI: https://shazzad.me
  * Text Domain: w4-post-list

--- a/w4-post-list.php
+++ b/w4-post-list.php
@@ -3,7 +3,7 @@
  * Plugin Name: W4 Post List
  * Plugin URI: https://w4dev.com/plugins/w4-post-list
  * Description: This plugin lets you create a list of - Posts, Terms, Users, Terms + Posts and Users + Posts. Outputs are completely customizable using Shortcode, HTML & CSS. Read documentation plugin usage.
- * Version: 2.5.4
+ * Version: 2.5.5
  * Requires at least: 5.8
  * Requires PHP: 5.7
  * Author: Shazzad Hossain Khan


### PR DESCRIPTION
## Summary
- Bump plugin version from 2.5.4 to 2.5.5
- Update WordPress "Tested up to" from 6.9 to 6.9.1
- Fix `Requires PHP` header from `5.7` (non-existent PHP version) to `7.4` to match `readme.txt`
- Fix malformed HTML `readonly` attribute in post updated messages input (`class-admin-main.php`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)