### PR TITLE
Add custom post status support to list settings

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,16 @@
 == Changelog ==
-= 2.4.9 = 
+= 2.5.6 =
+* New: Post status options now include all registered statuses, including custom ones (e.g. "Expired" from job listing plugins) - https://github.com/w4devInc/w4-post-list/issues/88.
+* Tested up to WordPress 7.0.2.
+= 2.5.5 =
+* Tested up to WordPress 6.9.1.
+= 2.5.4 =
+* Fix: Sanitized media image width and height attributes - https://github.com/w4devInc/w4-post-list/issues/64.
+= 2.5.3 =
+* Fix: Fixed version number.
+= 2.5.1 =
+* Fix: Fixed textdomain issue.
+= 2.4.9 =
 * Updated: Text localization.
 = 2.4.8 = 
 * Fix: Prev page navigation button weren't showing on page 2.

--- a/includes/class-config.php
+++ b/includes/class-config.php
@@ -97,6 +97,29 @@ class W4PL_Config {
 	}
 
 	/**
+	 * Post status choices
+	 *
+	 * Includes all registered non-internal statuses, so custom statuses
+	 * added by other plugins are selectable.
+	 *
+	 * @return array [description]
+	 */
+	public static function post_status_options() {
+		$return = array(
+			'any' => __( 'Any', 'w4-post-list' ),
+		);
+
+		foreach ( get_post_stati( array( 'internal' => false ), 'objects' ) as $post_status => $post_status_object ) {
+			$return[ $post_status ] = $post_status_object->label;
+		}
+
+		// Attachment status, registered as internal but queryable.
+		$return['inherit'] = __( 'Inherit', 'w4-post-list' );
+
+		return $return;
+	}
+
+	/**
 	 * [post_mime_type_options description]
 	 *
 	 * @param  string $post_types [description].

--- a/includes/class-w4-post-list.php
+++ b/includes/class-w4-post-list.php
@@ -29,7 +29,7 @@ final class W4_Post_List {
 	 *
 	 * @var string
 	 */
-	public $version = '2.5.5';
+	public $version = '2.5.6';
 
 	/**
 	 * This will hold current class instance

--- a/includes/helpers/class-helper-posts.php
+++ b/includes/helpers/class-helper-posts.php
@@ -77,13 +77,8 @@ class W4PL_Helper_Posts {
 			'name'        => 'w4pl[post_status]',
 			'label'       => __( 'Post status', 'w4-post-list' ),
 			'type'        => 'checkbox',
-			'option'      => array(
-				'any'     => __( 'Any', 'w4-post-list' ),
-				'publish' => __( 'Publish', 'w4-post-list' ),
-				'pending' => __( 'Pending', 'w4-post-list' ),
-				'future'  => __( 'Future', 'w4-post-list' ),
-				'inherit' => __( 'Inherit', 'w4-post-list' ),
-			),
+			'option'      => W4PL_Config::post_status_options(),
+			'desc'        => __( 'Note: "Any" excludes statuses that are hidden from search. Check a status directly to include it.', 'w4-post-list' ),
 		);
 
 		$fields['post_s']          = array(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "w4-post-list",
-	"version": "2.5.5",
+	"version": "2.5.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "w4-post-list",
-			"version": "2.5.5",
+			"version": "2.5.6",
 			"license": "GPL-3.0-or-later",
 			"devDependencies": {
 				"@wordpress/api-fetch": "^6.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "w4-post-list",
-	"version": "2.5.5",
+	"version": "2.5.6",
 	"description": "A WordPress Plugin for listing posts in some handy manner.",
 	"main": "Gruntfile.js",
 	"scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: sajib1223
 Tags: post, post list, custom post type, shortcode, media
 Requires at least: 5.8
-Tested up to: 6.9.1
+Tested up to: 7.0.2
 Requires PHP: 7.4
-Stable tag: 2.5.5
+Stable tag: 2.5.6
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -112,6 +112,9 @@ Each list have a unique id. Display a list by using `[postlist id="LIST_ID"]`.
 3. Preview 2
 
 == Changelog ==
+= 2.5.6 =
+* New: Post status options now include all registered statuses, including custom ones (e.g. "Expired" from job listing plugins) - https://github.com/w4devInc/w4-post-list/issues/88.
+* Tested up to WordPress 7.0.2.
 = 2.5.5 =
 * Tested up to WordPress 6.9.1.
 = 2.5.4 =
@@ -125,6 +128,9 @@ Each list have a unique id. Display a list by using `[postlist id="LIST_ID"]`.
 [See changelog of all versions](https://raw.githubusercontent.com/w4devInc/w4-post-list/master/CHANGELOG.txt).
 
 == Upgrade Notice ==
+= 2.5.6 =
+* New: Post status options now include all registered statuses, including custom ones (e.g. "Expired" from job listing plugins) - https://github.com/w4devInc/w4-post-list/issues/88.
+* Tested up to WordPress 7.0.2.
 = 2.5.5 =
 * Tested up to WordPress 6.9.1.
 = 2.5.4 =

--- a/w4-post-list.php
+++ b/w4-post-list.php
@@ -3,7 +3,7 @@
  * Plugin Name: W4 Post List
  * Plugin URI: https://w4dev.com/plugins/w4-post-list
  * Description: This plugin lets you create a list of - Posts, Terms, Users, Terms + Posts and Users + Posts. Outputs are completely customizable using Shortcode, HTML & CSS. Read documentation plugin usage.
- * Version: 2.5.5
+ * Version: 2.5.6
  * Requires at least: 5.8
  * Requires PHP: 7.4
  * Author: Shazzad Hossain Khan


### PR DESCRIPTION
## Summary
- Post Status options in the list settings are now built dynamically from all registered non-internal statuses via new `W4PL_Config::post_status_options()`, so custom statuses registered by other plugins (e.g. "Expired" from job listing plugins) are selectable checkboxes
- Core `draft` and `private` statuses, previously missing from the hardcoded list, now appear as well
- Added field help text clarifying that "Any" excludes search-hidden statuses (core `WP_Query` behavior) and the status must be checked directly
- Version bumped to 2.5.6, "Tested up to" raised to WordPress 7.0.2, missing 2.5.x entries backfilled in CHANGELOG.txt

Closes #88

## Test plan
- [x] `W4PL_Config::post_status_options()` returns Any, Published, Scheduled, Draft, Pending, Private, Inherit + custom statuses (verified in Docker env with a `job_listing` CPT registering `expired`/`filled` statuses mimicking WP Job Manager, including `exclude_from_search => true`)
- [x] List with the custom status checked renders posts in that status via `[postlist]`
- [x] "Any" still excludes `exclude_from_search` statuses (unchanged core behavior, now documented in the field description)
- [x] Existing saved lists unaffected — selections pass through to `WP_Query` exactly as before
- [x] PHPCS (project ruleset) clean on changed lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)