### PR TITLE
Add WordPress Playground blueprint for wp.org Live Preview

### DIFF
--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://playground.wordpress.net/blueprint-schema.json",
+  "landingPage": "/w4pl-demo/",
+  "preferredVersions": {
+    "php": "8.2",
+    "wp": "latest"
+  },
+  "phpExtensionBundles": [
+    "kitchen-sink"
+  ],
+  "steps": [
+    {
+      "step": "login",
+      "username": "admin",
+      "password": "password"
+    },
+    {
+      "step": "installPlugin",
+      "pluginZipFile": {
+        "resource": "wordpress.org/plugins",
+        "slug": "w4-post-list"
+      },
+      "options": {
+        "activate": true
+      }
+    },
+    {
+      "step": "runPHP",
+      "code": "<?php\nrequire_once 'wordpress/wp-load.php';\n$demo_posts = array(\n\tarray( 'A fresh look for the demo site', '2026-05-30 10:00:00' ),\n\tarray( 'Getting more from custom fields', '2026-01-05 09:00:00' ),\n\tarray( 'Our year in review', '2025-09-14 12:00:00' ),\n\tarray( 'Interview with a plugin author', '2025-06-21 08:30:00' ),\n\tarray( 'Ten tips for faster sites', '2024-11-02 15:00:00' ),\n\tarray( 'Hello from the archive', '2024-03-10 11:00:00' ),\n);\nforeach ( $demo_posts as $p ) {\n\twp_insert_post( array(\n\t\t'post_title'   => $p[0],\n\t\t'post_status'  => 'publish',\n\t\t'post_date'    => $p[1],\n\t\t'post_content' => 'Demo content for the W4 Post List preview.',\n\t) );\n}\n$list_id = wp_insert_post( array(\n\t'post_type'   => 'w4pl',\n\t'post_title'  => 'Demo: Posts grouped by year',\n\t'post_status' => 'publish',\n) );\nupdate_post_meta( $list_id, '_w4pl', array(\n\t'list_type'      => 'posts',\n\t'post_type'      => array( 'post' ),\n\t'posts_per_page' => 10,\n\t'orderby'        => 'post_date',\n\t'order'          => 'DESC',\n\t'groupby'        => 'year',\n\t'template'       => \"<ul>\\n[groups]\\n\\t<li><strong>[group_title]</strong>\\n\\t<ol>\\n\\t[posts]\\n\\t\\t<li><a href=\\\"[post_permalink]\\\">[post_title]</a></li>\\n\\t[/posts]\\n\\t</ol>\\n\\t</li>\\n[/groups]\\n</ul>\",\n) );\nwp_insert_post( array(\n\t'post_type'    => 'page',\n\t'post_title'   => 'W4 Post List demo',\n\t'post_name'    => 'w4pl-demo',\n\t'post_status'  => 'publish',\n\t'post_content' => '[postlist id=\"' . $list_id . '\"]',\n) );\n"
+    }
+  ]
+}

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,6 @@
 == Changelog ==
+= 2.5.9 =
+* New: Added a WordPress Playground blueprint that powers the Live Preview button on the wordpress.org plugin page.
 = 2.5.8 =
 * Fix: Documentation examples used unregistered template tags ([post_link], [group_name], [group_link]) and invalid HTML, so copy-pasting them produced broken output. All examples now use registered tags with valid loop markup.
 * New: "Getting Started" documentation tab with a step-by-step walkthrough, now the default tab.

--- a/includes/class-w4-post-list.php
+++ b/includes/class-w4-post-list.php
@@ -29,7 +29,7 @@ final class W4_Post_List {
 	 *
 	 * @var string
 	 */
-	public $version = '2.5.8';
+	public $version = '2.5.9';
 
 	/**
 	 * This will hold current class instance

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "w4-post-list",
-	"version": "2.5.8",
+	"version": "2.5.9",
 	"description": "A WordPress Plugin for listing posts in some handy manner.",
 	"main": "Gruntfile.js",
 	"scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: post list, user list, post grid, category list, shortcode
 Requires at least: 5.8
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 2.5.8
+Stable tag: 2.5.9
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -116,6 +116,8 @@ In your admin: **W4 Post List → Documentation** (template tags reference, exam
 
 
 == Changelog ==
+= 2.5.9 =
+* New: Added a WordPress Playground blueprint that powers the Live Preview button on the wordpress.org plugin page.
 = 2.5.8 =
 * Fix: Documentation examples used unregistered template tags ([post_link], [group_name], [group_link]) and invalid HTML, so copy-pasting them produced broken output. All examples now use registered tags with valid loop markup.
 * New: "Getting Started" documentation tab with a step-by-step walkthrough, now the default tab.
@@ -142,6 +144,8 @@ In your admin: **W4 Post List → Documentation** (template tags reference, exam
 [See changelog of all versions](https://raw.githubusercontent.com/w4devInc/w4-post-list/master/CHANGELOG.txt).
 
 == Upgrade Notice ==
+= 2.5.9 =
+Adds a Live Preview blueprint for the wordpress.org plugin page. No functional changes.
 = 2.5.8 =
 Documentation fixes: examples now copy-paste correctly, new Getting Started guide, docs visible to Editors.
 = 2.5.7 =

--- a/w4-post-list.php
+++ b/w4-post-list.php
@@ -3,7 +3,7 @@
  * Plugin Name: W4 Post List
  * Plugin URI: https://w4dev.com/plugins/w4-post-list
  * Description: Create lists of posts, terms and users — grouped archives, taxonomy indexes and user directories — placed anywhere with the block, [postlist] shortcode or widget.
- * Version: 2.5.8
+ * Version: 2.5.9
  * Requires at least: 5.8
  * Requires PHP: 7.4
  * Author: Shazzad Hossain Khan


### PR DESCRIPTION
## Summary
- Add `.wordpress-org/blueprints/blueprint.json` — a [WordPress Playground blueprint](https://developer.wordpress.org/plugins/wordpress-org/previews-and-blueprints/) that powers the **Live Preview** button on the wordpress.org plugin page (the one weDocs has)
- The preview: installs + activates W4 Post List, logs in as admin, seeds 6 demo posts spanning 2024–2026, creates a "Demo: Posts grouped by year" list (the plugin's differentiator — core's Query Loop can't group), embeds it on a page via `[postlist id]`, and lands the visitor on that page with real rendered output
- The demo `_w4pl` options array was verified end-to-end against the actual render pipeline in the docker dev site (`wp eval-file` → `do_shortcode` → grouped output confirmed)

## How it goes live
1. Merge; the file rides to SVN `assets/blueprints/blueprint.json` with the **next release deploy** (the 10up deploy action syncs `.wordpress-org/` on every tag run)
2. On the plugin page (logged in as committer) you'll see a **Test Preview** link — try it
3. The public Live Preview button is **hidden by default**; enable it from the committer-only controls on the plugin page once you're happy with the preview

## Test plan
- [ ] JSON validates (done — `json.load` passes)
- [ ] After next release deploy: `assets/blueprints/blueprint.json` appears in SVN
- [ ] "Test Preview" on the plugin page boots to `/w4pl-demo/` showing the year-grouped list
- [ ] Enable the public preview button

🤖 Generated with [Claude Code](https://claude.com/claude-code)