### PR TITLE
Fix asset-update workflow: IGNORE_OTHER_FILES + manual dispatch

### DIFF
--- a/.github/workflows/asset-update.yml
+++ b/.github/workflows/asset-update.yml
@@ -1,6 +1,7 @@
 name: Update WordPress.org Assets
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -22,3 +23,4 @@ jobs:
         env:
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+          IGNORE_OTHER_FILES: true


### PR DESCRIPTION
## Summary
- First run of the asset-update workflow failed on the action's safety check: SVN trunk contains build artifacts (block build.js/build.asset.php, .pot) regenerated at release time, which never match the repo's committed copies, so the action refused to deploy ("Other files have been modified")
- `IGNORE_OTHER_FILES: true` is the action's documented flag for exactly this: commit only `assets/` + readme changes, leave trunk untouched (trunk remains the release workflow's job)
- Add `workflow_dispatch` so the workflow can be triggered manually (needed now, since re-running the failed run would use the old workflow definition)

## Test plan
- [ ] After merge, `gh workflow run` the workflow manually — it should commit the new banner/icon files to SVN assets and go green

🤖 Generated with [Claude Code](https://claude.com/claude-code)