### PR TITLE
v2.6.0: Safety rails — test suite, options versioning, telemetry (M3)

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -21,3 +21,9 @@
 /phpcs.xml
 /README.md
 /.distignore
+/vendor-dev
+/wp
+/tests
+/composer-dev.json
+/composer-dev.lock
+/phpunit.xml.dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,10 @@
-name: Deploy to WordPress.org Repository
+name: CI
 
 on:
   push:
-    tags:
-      - "*"
+    branches:
+      - main
+  pull_request:
 
 jobs:
   test:
@@ -50,36 +51,23 @@ jobs:
           WP_TESTS_DB_PASSWORD: root
           WP_TESTS_DB_NAME: w4pl_tests
 
-  deploy_to_wp_repository:
-    name: Deploy to WP.org
+  phpcs:
+    name: Coding standards (advisory)
     runs-on: ubuntu-latest
-    needs: test
+    continue-on-error: true
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Build
-        run: |
-          npm install
-          npm run build-block
-          npm run build-plugin
-
-      - name: WordPress Plugin Deploy
-        id: deploy
-        uses: 10up/action-wordpress-plugin-deploy@stable
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
         with:
-          generate-zip: true
+          php-version: "8.2"
+          coverage: none
 
-        env:
-          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
-          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+      - name: Install dev dependencies
+        run: COMPOSER=composer-dev.json composer install --no-interaction --no-progress
 
-      - name: Upload release asset
-        uses: softprops/action-gh-release@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-        with:
-          # Provide what the file should be named when attached to the release (plugin-name.zip)
-          files: ${{ github.workspace }}/${{ github.event.repository.name }}.zip
+      - name: Run phpcs
+        run: vendor-dev/bin/phpcs --standard=phpcs.xml --report=summary .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,6 @@ jobs:
   phpcs:
     name: Coding standards (advisory)
     runs-on: ubuntu-latest
-    continue-on-error: true
 
     steps:
       - name: Checkout code
@@ -69,5 +68,7 @@ jobs:
       - name: Install dev dependencies
         run: COMPOSER=composer-dev.json composer install --no-interaction --no-progress
 
-      - name: Run phpcs
-        run: vendor-dev/bin/phpcs --standard=phpcs.xml --report=summary .
+      - name: Run phpcs (does not block)
+        run: |
+          vendor-dev/bin/phpcs --standard=phpcs.xml --report=summary . \
+            || echo "::warning::phpcs reports pre-existing violations (advisory; a dedicated cleanup release will address them)"

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 /vendor/**/.github
 /vendor/**/.git
 /vendor/**/readme.md
+# Dev tooling (composer-dev.json)
+/vendor-dev
+/wp
+/.phpunit.result.cache

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,11 @@
 == Changelog ==
+= 2.6.0 =
+* New: Automated test suite now gates every release - characterization snapshots freeze the rendered output of all five list types (including grouped lists and pagination) so updates can no longer break existing lists unnoticed.
+* New: List options now carry a schema version with a lazy migration path, protecting saved lists during future upgrades.
+* New: Opt-in usage counters (lists created/published) added to the existing Appsero telemetry. Nothing is collected without your explicit consent.
+* Fix: PHP 8.2+ deprecation notices from the query classes (dynamic properties).
+* Dev: Docs-drift guard - documentation examples, default templates and presets are verified in CI against the registered template tags.
+* Dev: Coding-standards nonce exclusion scoped to legacy files only; new endpoints are always linted for nonce verification.
 = 2.5.9 =
 * New: Added a WordPress Playground blueprint that powers the Live Preview button on the wordpress.org plugin page.
 = 2.5.8 =

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@
 * New: List options now carry a schema version with a lazy migration path, protecting saved lists during future upgrades.
 * New: Opt-in usage counters (lists created/published) added to the existing Appsero telemetry. Nothing is collected without your explicit consent.
 * Fix: PHP 8.2+ deprecation notices from the query classes (dynamic properties).
+* Fix: Unit-suffixed dimensions in template tags (e.g. [post_thumbnail width="50px"]) caused a PHP notice and broken output on PHP 7.x - dimensions are now parsed forgivingly (50px, 50 and "50" all work).
 * Dev: Docs-drift guard - documentation examples, default templates and presets are verified in CI against the registered template tags.
 * Dev: Coding-standards nonce exclusion scoped to legacy files only; new endpoints are always linted for nonce verification.
 = 2.5.9 =

--- a/appsero.php
+++ b/appsero.php
@@ -145,6 +145,12 @@ function w4pl_insights_extra() {
 		$extra['VisualComposer'] = 'Active';
 	}
 
+	if ( class_exists( 'W4PL_Stats' ) ) {
+		foreach ( W4PL_Stats::all() as $key => $value ) {
+			$extra[ 'Stat_' . $key ] = (int) $value;
+		}
+	}
+
 	return $extra;
 }
 

--- a/composer-dev.json
+++ b/composer-dev.json
@@ -1,0 +1,27 @@
+{
+	"name": "w4devinc/w4-post-list-dev",
+	"description": "Dev-only tooling (tests, coding standards). Kept separate from composer.json because vendor/ is committed and shipped.",
+	"license": "GPL-3.0-or-later",
+	"config": {
+		"vendor-dir": "vendor-dev",
+		"platform": {
+			"php": "7.4.33"
+		},
+		"allow-plugins": {
+			"johnpbloch/wordpress-core-installer": true,
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
+	},
+	"require-dev": {
+		"phpunit/phpunit": "^9.6",
+		"wp-phpunit/wp-phpunit": "~7.0.0",
+		"yoast/phpunit-polyfills": "^2.0",
+		"johnpbloch/wordpress-core-installer": "^2.0",
+		"johnpbloch/wordpress-core": "~7.0.0",
+		"wp-coding-standards/wpcs": "^3.0",
+		"dealerdirect/phpcodesniffer-composer-installer": "^1.0"
+	},
+	"extra": {
+		"wordpress-install-dir": "wp"
+	}
+}

--- a/composer-dev.lock
+++ b/composer-dev.lock
@@ -1,0 +1,2431 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "f44942a495ca7055b1347f9172c4c87f",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/composer-installer.git",
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.2",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.1.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.2",
+                "ext-json": "*",
+                "ext-zip": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcompatibility/php-compatibility": "^9.0 || ^10.0.0@dev",
+                "yoast/phpunit-polyfills": "^1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "opensource@frenck.dev",
+                    "homepage": "https://frenck.dev",
+                    "role": "Open source developer"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/composer-installer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcbf",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/composer-installer/issues",
+                "security": "https://github.com/PHPCSStandards/composer-installer/security/policy",
+                "source": "https://github.com/PHPCSStandards/composer-installer"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2026-05-06T08:26:05+00:00"
+        },
+        {
+            "name": "doctrine/instantiator",
+            "version": "1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9 || ^11",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpbench/phpbench": "^0.16 || ^1",
+                "phpstan/phpstan": "^1.4",
+                "phpstan/phpstan-phpunit": "^1",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "vimeo/psalm": "^4.30 || ^5.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "https://ocramius.github.io/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/1.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-12-30T00:15:36+00:00"
+        },
+        {
+            "name": "johnpbloch/wordpress-core",
+            "version": "7.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/johnpbloch/wordpress-core.git",
+                "reference": "7c0153862c16407dce737ccc87a64a25953b687b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/johnpbloch/wordpress-core/zipball/7c0153862c16407dce737ccc87a64a25953b687b",
+                "reference": "7c0153862c16407dce737ccc87a64a25953b687b",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=7.4"
+            },
+            "provide": {
+                "wordpress/core-implementation": "7.0.2"
+            },
+            "type": "wordpress-core",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "WordPress Community",
+                    "homepage": "https://wordpress.org/about/"
+                }
+            ],
+            "description": "WordPress is open source software you can use to create a beautiful website, blog, or app.",
+            "homepage": "https://wordpress.org/",
+            "keywords": [
+                "blog",
+                "cms",
+                "wordpress"
+            ],
+            "support": {
+                "forum": "https://wordpress.org/support/",
+                "irc": "irc://irc.freenode.net/wordpress",
+                "issues": "https://core.trac.wordpress.org/",
+                "source": "https://core.trac.wordpress.org/browser",
+                "wiki": "https://codex.wordpress.org/"
+            },
+            "time": "2026-07-17T18:48:27+00:00"
+        },
+        {
+            "name": "johnpbloch/wordpress-core-installer",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/johnpbloch/wordpress-core-installer.git",
+                "reference": "237faae9a60a4a2e1d45dce1a5836ffa616de63e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/johnpbloch/wordpress-core-installer/zipball/237faae9a60a4a2e1d45dce1a5836ffa616de63e",
+                "reference": "237faae9a60a4a2e1d45dce1a5836ffa616de63e",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.6.0"
+            },
+            "conflict": {
+                "composer/installers": "<1.0.6"
+            },
+            "require-dev": {
+                "composer/composer": "^1.0 || ^2.0",
+                "phpunit/phpunit": ">=5.7.27"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "johnpbloch\\Composer\\WordPressCorePlugin"
+            },
+            "autoload": {
+                "psr-0": {
+                    "johnpbloch\\Composer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "John P. Bloch",
+                    "email": "me@johnpbloch.com"
+                }
+            ],
+            "description": "A custom installer to handle deploying WordPress with composer",
+            "keywords": [
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/johnpbloch/wordpress-core-installer/issues",
+                "source": "https://github.com/johnpbloch/wordpress-core-installer/tree/master"
+            },
+            "time": "2020-04-16T21:44:57+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.8.0"
+            },
+            "time": "2026-07-04T14:30:18+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsextra",
+            "version": "1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
+                "reference": "b598aa890815b8df16363271b659d73280129101"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/b598aa890815b8df16363271b659d73280129101",
+                "reference": "b598aa890815b8df16363271b659d73280129101",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpcsstandards/phpcsutils": "^1.2.0",
+                "squizlabs/php_codesniffer": "^3.13.5 || ^4.0.1"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcsstandards/phpcsdevcs": "^1.2.0",
+                "phpcsstandards/phpcsdevtools": "^1.2.1",
+                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSExtra/graphs/contributors"
+                }
+            ],
+            "description": "A collection of sniffs and standards for use with PHP_CodeSniffer.",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHPCSExtra/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSExtra/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHPCSExtra"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-11-12T23:06:57+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsutils",
+            "version": "1.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
+                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
+                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.13.5 || ^4.0.1"
+            },
+            "require-dev": {
+                "ext-filter": "*",
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcsstandards/phpcsdevcs": "^1.2.0",
+                "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0 || ^3.0.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PHPCSUtils/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSUtils/graphs/contributors"
+                }
+            ],
+            "description": "A suite of utility functions for use with PHP_CodeSniffer",
+            "homepage": "https://phpcsutils.com/",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "phpcs3",
+                "phpcs4",
+                "standards",
+                "static analysis",
+                "tokens",
+                "utility"
+            ],
+            "support": {
+                "docs": "https://phpcsutils.com/",
+                "issues": "https://github.com/PHPCSStandards/PHPCSUtils/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSUtils/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHPCSUtils"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-12-08T14:27:58+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "9.2.32",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
+                "php": ">=7.3",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-text-template": "^2.0.4",
+                "sebastian/code-unit-reverse-lookup": "^2.0.3",
+                "sebastian/complexity": "^2.0.3",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/lines-of-code": "^1.0.4",
+                "sebastian/version": "^3.0.2",
+                "theseer/tokenizer": "^1.2.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "9.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.32"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-22T04:23:01+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "3.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-12-02T12:48:52+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:58:55+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T05:33:50+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "5.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:16:10+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "9.6.35",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "0edba2f3a0c48df3553cb9b640810b30df60302b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0edba2f3a0c48df3553cb9b640810b30df60302b",
+                "reference": "0edba2f3a0c48df3553cb9b640810b30df60302b",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.5.0 || ^2",
+                "ext-dom": "*",
+                "ext-filter": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=7.3",
+                "phpunit/php-code-coverage": "^9.2.32",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-invoker": "^3.1.1",
+                "phpunit/php-text-template": "^2.0.4",
+                "phpunit/php-timer": "^5.0.3",
+                "sebastian/cli-parser": "^1.0.2",
+                "sebastian/code-unit": "^1.0.8",
+                "sebastian/comparator": "^4.0.10",
+                "sebastian/diff": "^4.0.6",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/exporter": "^4.0.8",
+                "sebastian/global-state": "^5.0.8",
+                "sebastian/object-enumerator": "^4.0.4",
+                "sebastian/resource-operations": "^3.0.4",
+                "sebastian/type": "^3.2.1",
+                "sebastian/version": "^3.0.2"
+            },
+            "suggest": {
+                "ext-soap": "To be able to generate mocks based on WSDL files",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.6-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.35"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsoring.html",
+                    "type": "other"
+                }
+            ],
+            "time": "2026-07-06T14:48:07+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T06:27:43+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:08:54+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:30:19+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "4.0.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/diff": "^4.0",
+                "sebastian/exporter": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.10"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-24T09:22:56+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:19:30+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T06:30:58+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "5.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:03:51+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "4.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-24T06:03:27+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "5.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T07:10:35+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:20:34+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:12:34+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:14:26+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/539c6691e0623af6dc6f9c20384c120f963465a0",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T06:57:39+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "3.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-14T16:00:52+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:13:03+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:39:44+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.13.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
+            },
+            "bin": [
+                "bin/phpcbf",
+                "bin/phpcs"
+            ],
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "Former lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "Current lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
+                "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+                "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-11-04T16:30:35+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-11-17T20:03:58+00:00"
+        },
+        {
+            "name": "wp-coding-standards/wpcs",
+            "version": "3.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
+                "reference": "469c18ceab4d642b15bad4c65ebf3b307bfd55ab"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/469c18ceab4d642b15bad4c65ebf3b307bfd55ab",
+                "reference": "469c18ceab4d642b15bad4c65ebf3b307bfd55ab",
+                "shasum": ""
+            },
+            "require": {
+                "ext-filter": "*",
+                "ext-libxml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlreader": "*",
+                "php": ">=7.2",
+                "phpcsstandards/phpcsextra": "^1.5.0",
+                "phpcsstandards/phpcsutils": "^1.2.2",
+                "squizlabs/php_codesniffer": "^3.13.5"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcompatibility/php-compatibility": "^10.0.0@dev",
+                "phpcsstandards/phpcsdevtools": "^1.2.0",
+                "phpunit/phpunit": "^8.0 || ^9.0"
+            },
+            "suggest": {
+                "ext-iconv": "For improved results",
+                "ext-mbstring": "For improved results"
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/WordPress/WordPress-Coding-Standards/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/WordPress/WordPress-Coding-Standards/issues",
+                "source": "https://github.com/WordPress/WordPress-Coding-Standards",
+                "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "custom"
+                }
+            ],
+            "time": "2026-07-16T13:05:29+00:00"
+        },
+        {
+            "name": "wp-phpunit/wp-phpunit",
+            "version": "7.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wp-phpunit/wp-phpunit.git",
+                "reference": "0d17335392d78b12b3e7e6b519cd53db728df52a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wp-phpunit/wp-phpunit/zipball/0d17335392d78b12b3e7e6b519cd53db728df52a",
+                "reference": "0d17335392d78b12b3e7e6b519cd53db728df52a",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "__loaded.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Evan Mattson",
+                    "email": "me@aaemnnost.tv"
+                },
+                {
+                    "name": "WordPress Community",
+                    "homepage": "https://wordpress.org/about/"
+                }
+            ],
+            "description": "WordPress core PHPUnit library",
+            "homepage": "https://github.com/wp-phpunit",
+            "keywords": [
+                "phpunit",
+                "test",
+                "wordpress"
+            ],
+            "support": {
+                "docs": "https://github.com/wp-phpunit/docs",
+                "issues": "https://github.com/wp-phpunit/issues",
+                "source": "https://github.com/wp-phpunit/wp-phpunit"
+            },
+            "time": "2026-07-10T02:38:55+00:00"
+        },
+        {
+            "name": "yoast/phpunit-polyfills",
+            "version": "2.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
+                "reference": "1a6aecc9ebe4a9cea4e1047d0e6c496e52314c27"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/1a6aecc9ebe4a9cea4e1047d0e6c496e52314c27",
+                "reference": "1a6aecc9ebe4a9cea4e1047d0e6c496e52314c27",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6",
+                "phpunit/phpunit": "^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "yoast/yoastcs": "^3.2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "phpunitpolyfills-autoload.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Team Yoast",
+                    "email": "support@yoast.com",
+                    "homepage": "https://yoast.com"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Yoast/PHPUnit-Polyfills/graphs/contributors"
+                }
+            ],
+            "description": "Set of polyfills for changed PHPUnit functionality to allow for creating PHPUnit cross-version compatible tests",
+            "homepage": "https://github.com/Yoast/PHPUnit-Polyfills",
+            "keywords": [
+                "phpunit",
+                "polyfill",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
+                "security": "https://github.com/Yoast/PHPUnit-Polyfills/security/policy",
+                "source": "https://github.com/Yoast/PHPUnit-Polyfills"
+            },
+            "time": "2025-08-10T05:13:49+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "platform-overrides": {
+        "php": "7.4.33"
+    },
+    "plugin-api-version": "2.3.0"
+}

--- a/includes/abstracts/class-query.php
+++ b/includes/abstracts/class-query.php
@@ -7,7 +7,12 @@
 
 /**
  * Query class
+ *
+ * Subclasses assign ad-hoc result properties at runtime; the attribute keeps
+ * that working without deprecation notices on PHP 8.2+ (it parses as a
+ * comment on PHP < 8.0).
  */
+#[AllowDynamicProperties]
 abstract class W4PL_Query {
 	/**
 	 * Query arguments

--- a/includes/class-options-migrator.php
+++ b/includes/class-options-migrator.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Options schema versioning and lazy migration.
+ *
+ * Every list's `_w4pl` options array carries an `options_version`. Options
+ * are migrated on read (priority 1 on `w4pl/pre_get_options`, before any
+ * helper touches them) and the migrated shape is persisted only when the
+ * list is next saved (`w4pl/pre_save_options`). Existing lists without the
+ * key are treated as version 0 and must keep rendering byte-identically —
+ * the snapshot suite in tests/ListRenderingTest.php enforces this.
+ *
+ * @class W4PL_Options_Migrator
+ * @package W4_Post_List
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Lazy migration of stored list options between schema versions.
+ */
+class W4PL_Options_Migrator {
+
+	/**
+	 * Current schema version of the _w4pl options array.
+	 */
+	const OPTIONS_VERSION = 1;
+
+	/**
+	 * Constructor
+	 */
+	public function __construct() {
+		add_filter( 'w4pl/pre_get_options', array( $this, 'migrate' ), 1 );
+		add_filter( 'w4pl/pre_save_options', array( $this, 'stamp_version' ), 99 );
+	}
+
+	/**
+	 * Migrate options read from storage up to the current schema version.
+	 *
+	 * Runs in memory on every read; nothing is written back here.
+	 *
+	 * @param  array $options List options as stored.
+	 * @return array
+	 */
+	public function migrate( $options ) {
+		if ( ! is_array( $options ) ) {
+			return $options;
+		}
+
+		$version = 0;
+		if ( isset( $options['options_version'] ) ) {
+			$version = (int) $options['options_version'];
+		}
+
+		if ( $version >= self::OPTIONS_VERSION ) {
+			return $options;
+		}
+
+		// One guarded block per schema step, e.g.:
+		// if ( $version < 2 ) { ...transform to shape 2... }
+		//
+		// Version 1 only introduces the version key itself. The historical
+		// 1.6.7 template_loop shim in W4PL_List_Helper::pre_get_options()
+		// intentionally stays in place until a schema step absorbs it.
+
+		$options['options_version'] = self::OPTIONS_VERSION;
+
+		return $options;
+	}
+
+	/**
+	 * Stamp the current schema version into options being saved.
+	 *
+	 * @param  array $options List options about to be persisted.
+	 * @return array
+	 */
+	public function stamp_version( $options ) {
+		if ( is_array( $options ) ) {
+			$options['options_version'] = self::OPTIONS_VERSION;
+		}
+
+		return $options;
+	}
+}

--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Anonymous usage counters.
+ *
+ * Counters accumulate locally in the `w4pl_stats` option and are only ever
+ * transmitted as part of the Appsero Insights ping, which the user must
+ * explicitly opt in to (see appsero.php / w4pl_insights_extra). No events
+ * are sent individually and nothing is collected without consent.
+ *
+ * Future features add their own counters via W4PL_Stats::increment().
+ *
+ * @class W4PL_Stats
+ * @package W4_Post_List
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Local usage counters for opt-in telemetry.
+ */
+class W4PL_Stats {
+
+	const OPTION = 'w4pl_stats';
+
+	/**
+	 * Constructor
+	 */
+	public function __construct() {
+		add_action( 'transition_post_status', array( $this, 'track_list_status' ), 10, 3 );
+	}
+
+	/**
+	 * Increment a named counter.
+	 *
+	 * @param string $key Counter name.
+	 * @param int    $by  Amount to add.
+	 */
+	public static function increment( $key, $by = 1 ) {
+		$stats = self::all();
+
+		if ( ! isset( $stats[ $key ] ) ) {
+			$stats[ $key ] = 0;
+		}
+
+		$stats[ $key ] = (int) $stats[ $key ] + $by;
+
+		update_option( self::OPTION, $stats, false );
+	}
+
+	/**
+	 * Get one counter value.
+	 *
+	 * @param  string $key Counter name.
+	 * @return int
+	 */
+	public static function get( $key ) {
+		$stats = self::all();
+
+		if ( ! isset( $stats[ $key ] ) ) {
+			return 0;
+		}
+
+		return (int) $stats[ $key ];
+	}
+
+	/**
+	 * Get all counters.
+	 *
+	 * @return array
+	 */
+	public static function all() {
+		$stats = get_option( self::OPTION, array() );
+
+		if ( ! is_array( $stats ) ) {
+			return array();
+		}
+
+		return $stats;
+	}
+
+	/**
+	 * Count list creations and first-time publishes.
+	 *
+	 * @param string  $new_status New post status.
+	 * @param string  $old_status Old post status.
+	 * @param WP_Post $post       Post object.
+	 */
+	public function track_list_status( $new_status, $old_status, $post ) {
+		if ( ! $post instanceof WP_Post || 'w4pl' !== $post->post_type ) {
+			return;
+		}
+
+		if ( in_array( $old_status, array( 'new', 'auto-draft' ), true ) && ! in_array( $new_status, array( 'new', 'auto-draft' ), true ) ) {
+			self::increment( 'lists_created' );
+		}
+
+		if ( 'publish' === $new_status && 'publish' !== $old_status ) {
+			self::increment( 'lists_published' );
+		}
+	}
+}

--- a/includes/class-w4-post-list.php
+++ b/includes/class-w4-post-list.php
@@ -29,7 +29,7 @@ final class W4_Post_List {
 	 *
 	 * @var string
 	 */
-	public $version = '2.5.9';
+	public $version = '2.6.0';
 
 	/**
 	 * This will hold current class instance
@@ -85,6 +85,8 @@ final class W4_Post_List {
 		include W4PL_DIR . '/includes/class-utils.php';
 		include W4PL_DIR . '/includes/class-config.php';
 		include W4PL_DIR . '/includes/class-post-types.php';
+		include W4PL_DIR . '/includes/class-options-migrator.php';
+		include W4PL_DIR . '/includes/class-stats.php';
 		include W4PL_DIR . '/includes/class-list-templates.php';
 		include W4PL_DIR . '/includes/class-list-helper.php';
 		include W4PL_DIR . '/includes/class-list-content.php';
@@ -146,6 +148,8 @@ final class W4_Post_List {
 		new W4PL_List_Shortcode();
 		new W4PL_Date_Shortcode();
 
+		new W4PL_Options_Migrator();
+		new W4PL_Stats();
 		new W4PL_List_Helper();
 		new W4PL_Helper_Posts();
 		new W4PL_Helper_Terms();

--- a/includes/template-tags/class-post-template-tags.php
+++ b/includes/template-tags/class-post-template-tags.php
@@ -641,25 +641,20 @@ class W4PL_Post_Template_Tags {
 	public static function featured_image( $attr, $cont ) {
 		if ( isset( $attr['size'] ) ) {
 			$size = $attr['size'];
-		} elseif ( isset( $attr['width'] ) ) {
-			$attr['width'] = trim( $attr['width'], 'px' );
-
-			if ( isset( $attr['height'] ) ) {
-				$height = $attr['height'];
-			} else {
-				$height = 9999;
+		} elseif ( isset( $attr['width'] ) || isset( $attr['height'] ) ) {
+			// Forgiving dimension parsing: "50px", "50" and 50 all mean 50;
+			// anything non-numeric falls back to unconstrained.
+			$width = 9999;
+			if ( isset( $attr['width'] ) && absint( $attr['width'] ) ) {
+				$width = absint( $attr['width'] );
 			}
 
-			$size = array( $attr['width'], $height );
-		} elseif ( isset( $attr['height'] ) ) {
-			$attr['height'] = trim( $attr['height'], 'px' );
-
-			if ( isset( $attr['width'] ) ) {
-				$width = $attr['width'];
-			} else {
-				$width = 9999;
+			$height = 9999;
+			if ( isset( $attr['height'] ) && absint( $attr['height'] ) ) {
+				$height = absint( $attr['height'] );
 			}
-			$size = array( $width, $attr['height'] );
+
+			$size = array( $width, $height );
 		} else {
 			$size = 'post-thumbnail';
 		}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "w4-post-list",
-	"version": "2.5.9",
+	"version": "2.6.0",
 	"description": "A WordPress Plugin for listing posts in some handy manner.",
 	"main": "Gruntfile.js",
 	"scripts": {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -5,6 +5,9 @@
 	<!-- Exclude paths -->
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
+	<exclude-pattern>*/vendor-dev/*</exclude-pattern>
+	<exclude-pattern>*/wp/*</exclude-pattern>
+	<exclude-pattern>*/tests/*</exclude-pattern>
 	<exclude-pattern>languages/*</exclude-pattern>
 
 	<!-- Configs -->
@@ -14,13 +17,21 @@
 	<!-- Rules -->
 	<rule ref="WordPress">
 		<exclude name="WordPress.Files.FileName.InvalidClassFileName"/>
-        <exclude name="WordPress.Security.NonceVerification.Missing"/>
 		<exclude name="WordPress.NamingConventions.ValidHookName.UseUnderscores"/>
     </rule>
 
 	<rule ref="WordPress.Files.FileName.InvalidClassFileName">
 		<exclude-pattern>includes/*.php</exclude-pattern>
 		<exclude-pattern>admin/*.php</exclude-pattern>
+	</rule>
+
+	<!--
+	Legacy save/AJAX paths predate nonce usage; they are scheduled for a
+	proper nonce in the editor-validation milestone. New code must NOT be
+	added to this list - every new endpoint verifies a nonce.
+	-->
+	<rule ref="WordPress.Security.NonceVerification.Missing">
+		<exclude-pattern>admin/class-admin-lists-metaboxes\.php</exclude-pattern>
 	</rule>
 
 	<rule ref="WordPress.WP.I18n">

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
+	bootstrap="tests/bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	beStrictAboutOutputDuringTests="true"
+	failOnWarning="true"
+>
+	<testsuites>
+		<testsuite name="w4pl">
+			<directory suffix="Test.php">tests</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: post list, user list, post grid, category list, shortcode
 Requires at least: 5.8
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 2.5.9
+Stable tag: 2.6.0
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -116,6 +116,13 @@ In your admin: **W4 Post List → Documentation** (template tags reference, exam
 
 
 == Changelog ==
+= 2.6.0 =
+* New: Automated test suite now gates every release - characterization snapshots freeze the rendered output of all five list types (including grouped lists and pagination) so updates can no longer break existing lists unnoticed.
+* New: List options now carry a schema version with a lazy migration path, protecting saved lists during future upgrades.
+* New: Opt-in usage counters (lists created/published) added to the existing Appsero telemetry. Nothing is collected without your explicit consent.
+* Fix: PHP 8.2+ deprecation notices from the query classes (dynamic properties).
+* Dev: Docs-drift guard - documentation examples, default templates and presets are verified in CI against the registered template tags.
+* Dev: Coding-standards nonce exclusion scoped to legacy files only; new endpoints are always linted for nonce verification.
 = 2.5.9 =
 * New: Added a WordPress Playground blueprint that powers the Live Preview button on the wordpress.org plugin page.
 = 2.5.8 =
@@ -144,6 +151,8 @@ In your admin: **W4 Post List → Documentation** (template tags reference, exam
 [See changelog of all versions](https://raw.githubusercontent.com/w4devInc/w4-post-list/master/CHANGELOG.txt).
 
 == Upgrade Notice ==
+= 2.6.0 =
+Adds automated release testing, options versioning and PHP 8.2 deprecation fixes. No changes to list output.
 = 2.5.9 =
 Adds a Live Preview blueprint for the wordpress.org plugin page. No functional changes.
 = 2.5.8 =

--- a/readme.txt
+++ b/readme.txt
@@ -121,6 +121,7 @@ In your admin: **W4 Post List → Documentation** (template tags reference, exam
 * New: List options now carry a schema version with a lazy migration path, protecting saved lists during future upgrades.
 * New: Opt-in usage counters (lists created/published) added to the existing Appsero telemetry. Nothing is collected without your explicit consent.
 * Fix: PHP 8.2+ deprecation notices from the query classes (dynamic properties).
+* Fix: Unit-suffixed dimensions in template tags (e.g. [post_thumbnail width="50px"]) caused a PHP notice and broken output on PHP 7.x - dimensions are now parsed forgivingly (50px, 50 and "50" all work).
 * Dev: Docs-drift guard - documentation examples, default templates and presets are verified in CI against the registered template tags.
 * Dev: Coding-standards nonce exclusion scoped to legacy files only; new endpoints are always linted for nonce verification.
 = 2.5.9 =

--- a/tests/DocsTagsTest.php
+++ b/tests/DocsTagsTest.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Docs-drift guard: every template tag used in shipped documentation
+ * examples, default templates, and presets must exist in the tag registry.
+ *
+ * This is the CI tripwire for the class of bug fixed in 2.5.8, where the
+ * official examples taught tags that were registered nowhere.
+ *
+ * @package W4_Post_List
+ */
+
+class DocsTagsTest extends WP_UnitTestCase {
+
+	/**
+	 * Extract candidate template tags from a template/HTML string.
+	 * Matches [tag ...] and [/tag], both raw and HTML-entity-encoded.
+	 */
+	protected function extract_tags( $content ) {
+		$content = html_entity_decode( $content, ENT_QUOTES );
+		preg_match_all( '/\[\/?([a-zA-Z_][a-zA-Z0-9_]*)[\s\]]/', $content, $m );
+
+		return array_unique( $m[1] );
+	}
+
+	protected function registered_tags() {
+		$tags = array_keys( w4pl_get_shortcodes() );
+
+		// The embed shortcode itself appears in docs and is registered with WP.
+		$tags[] = 'postlist';
+
+		return $tags;
+	}
+
+	protected function assertTagsRegistered( $used, $source ) {
+		$unknown = array_diff( $used, $this->registered_tags() );
+
+		$this->assertSame(
+			array(),
+			array_values( $unknown ),
+			"Unregistered template tags referenced in $source: " . implode( ', ', $unknown )
+		);
+	}
+
+	public function test_doc_examples_use_only_registered_tags() {
+		$file = dirname( __DIR__ ) . '/admin/pages/views/html-template-examples.php';
+		$this->assertTagsRegistered( $this->extract_tags( file_get_contents( $file ) ), 'html-template-examples.php' );
+	}
+
+	public function test_default_templates_use_only_registered_tags() {
+		$templates = new W4PL_List_Templates();
+
+		foreach ( array( 'posts', 'terms', 'users', 'terms.posts', 'users.posts' ) as $type ) {
+			$template = $templates->sanitize_template( '', array( 'list_type' => $type ) );
+			$this->assertNotEmpty( $template, "No default template for $type" );
+			$this->assertTagsRegistered( $this->extract_tags( $template ), "default template for $type" );
+		}
+	}
+
+	public function test_preset_templates_use_only_registered_tags() {
+		$presets = new W4PL_Helper_Presets();
+		$combos  = array(
+			array( 'simple_list', 'posts' ),
+			array( 'simple_list', 'terms' ),
+			array( 'simple_list', 'users' ),
+			array( 'simple_list', 'terms.posts' ),
+			array( 'simple_list', 'users.posts' ),
+			array( 'post_with_thumbnail', 'posts' ),
+			array( 'post_with_thumbnail', 'terms.posts' ),
+			array( 'post_with_thumbnail', 'users.posts' ),
+		);
+
+		foreach ( $combos as $combo ) {
+			$options = $presets->pre_get_options(
+				array(
+					'preset'    => $combo[0],
+					'list_type' => $combo[1],
+				)
+			);
+			$this->assertNotEmpty( $options['template'], "Preset {$combo[0]} produced no template for {$combo[1]}" );
+			$this->assertTagsRegistered( $this->extract_tags( $options['template'] ), "preset {$combo[0]} / {$combo[1]}" );
+		}
+	}
+}

--- a/tests/ListRenderingTest.php
+++ b/tests/ListRenderingTest.php
@@ -1,0 +1,262 @@
+<?php
+/**
+ * Characterization tests for the options -> HTML rendering contract.
+ *
+ * These snapshots freeze the output of the rendering pipeline for all five
+ * list types. They are the compatibility guarantee for lists stored on
+ * existing sites: a refactor that changes any snapshot is a breaking change
+ * until proven otherwise. Regenerate deliberately with:
+ *
+ *   W4PL_UPDATE_SNAPSHOTS=1 vendor-dev/bin/phpunit --filter ListRenderingTest
+ *
+ * @package W4_Post_List
+ */
+
+class ListRenderingTest extends WP_UnitTestCase {
+
+	protected static $cat_alpha;
+	protected static $cat_beta;
+	protected static $user_ann;
+	protected static $user_bob;
+	protected static $post_ids = array();
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$cat_alpha = $factory->term->create(
+			array(
+				'taxonomy' => 'category',
+				'name'     => 'Alpha',
+				'slug'     => 'alpha',
+			)
+		);
+		self::$cat_beta  = $factory->term->create(
+			array(
+				'taxonomy' => 'category',
+				'name'     => 'Beta',
+				'slug'     => 'beta',
+			)
+		);
+
+		self::$user_ann = $factory->user->create(
+			array(
+				'role'         => 'author',
+				'user_login'   => 'ann',
+				'display_name' => 'Ann Author',
+			)
+		);
+		self::$user_bob = $factory->user->create(
+			array(
+				'role'         => 'author',
+				'user_login'   => 'bob',
+				'display_name' => 'Bob Builder',
+			)
+		);
+
+		$fixtures = array(
+			array( 'Winter release notes', '2026-01-05 09:00:00', self::$cat_alpha, self::$user_ann ),
+			array( 'Spring cleaning tips', '2026-04-10 10:00:00', self::$cat_beta, self::$user_bob ),
+			array( 'Year in review', '2025-09-14 12:00:00', self::$cat_alpha, self::$user_ann ),
+			array( 'Interview with a builder', '2025-06-21 08:30:00', self::$cat_beta, self::$user_bob ),
+			array( 'Ten tips for faster sites', '2024-11-02 15:00:00', self::$cat_alpha, self::$user_ann ),
+			array( 'Hello from the archive', '2024-03-10 11:00:00', self::$cat_beta, self::$user_bob ),
+		);
+
+		foreach ( $fixtures as $f ) {
+			self::$post_ids[] = $factory->post->create(
+				array(
+					'post_title'    => $f[0],
+					'post_date'     => $f[1],
+					'post_category' => array( $f[2] ),
+					'post_author'   => $f[3],
+					'post_content'  => 'Fixture content for ' . $f[0] . '.',
+					'post_excerpt'  => 'Excerpt for ' . $f[0] . '.',
+				)
+			);
+		}
+	}
+
+	/**
+	 * Render a list from an options array through the same path the
+	 * [postlist] shortcode uses: a real w4pl post with _w4pl meta.
+	 */
+	protected function render_list( array $options ) {
+		$list_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'w4pl',
+				'post_title'  => 'Characterization list',
+				'post_status' => 'publish',
+			)
+		);
+		update_post_meta( $list_id, '_w4pl', $options );
+
+		return do_shortcode( '[postlist id="' . $list_id . '"]' );
+	}
+
+	/**
+	 * Strip run-dependent identifiers so snapshots are stable across runs.
+	 */
+	protected function normalize( $html ) {
+		$patterns = array(
+			'/W4PL_List_\d+/'                 => 'W4PL_List_{ID}',
+			'/w4pl-list-\d+/'                 => 'w4pl-list-{ID}',
+			'/w4pl-inner-\d+/'                => 'w4pl-inner-{ID}',
+			'/w4pl-\d+/'                      => 'w4pl-{ID}',
+			'/\?p=\d+/'                       => '?p={ID}',
+			'/\?page_id=\d+/'                 => '?page_id={ID}',
+			'/\?cat=\d+/'                     => '?cat={ID}',
+			'/\?author=\d+/'                  => '?author={ID}',
+			'/page\d+=(\d+)/'                 => 'page{ID}=$1',
+			'/\b(post|tag|category|user|term)[-_]item[-_]\d+/' => '$1-item-{ID}',
+			'/\bpost-\d+\b/'                  => 'post-{ID}',
+			'/\btag-\d+\b/'                   => 'tag-{ID}',
+		);
+
+		$html = preg_replace( array_keys( $patterns ), array_values( $patterns ), $html );
+
+		// Trim per-line trailing whitespace; keep structure otherwise.
+		$html = preg_replace( '/[ \t]+$/m', '', $html );
+
+		return trim( $html ) . "\n";
+	}
+
+	protected function assertMatchesHtmlSnapshot( $name, $html ) {
+		$normalized = $this->normalize( $html );
+		$dir        = __DIR__ . '/snapshots';
+		$file       = $dir . '/' . $name . '.html';
+
+		if ( getenv( 'W4PL_UPDATE_SNAPSHOTS' ) ) {
+			if ( ! is_dir( $dir ) ) {
+				mkdir( $dir, 0777, true );
+			}
+			file_put_contents( $file, $normalized );
+		}
+
+		$this->assertFileExists( $file, "Snapshot '$name' missing. Generate with W4PL_UPDATE_SNAPSHOTS=1." );
+		$this->assertSame( file_get_contents( $file ), $normalized, "Rendered HTML diverged from snapshot '$name'." );
+	}
+
+	public function test_posts_list_default_template() {
+		$html = $this->render_list(
+			array(
+				'list_type'      => 'posts',
+				'post_type'      => array( 'post' ),
+				'posts_per_page' => 10,
+				'orderby'        => 'post_date',
+				'order'          => 'DESC',
+			)
+		);
+		$this->assertMatchesHtmlSnapshot( 'posts-default', $html );
+	}
+
+	public function test_posts_list_custom_template() {
+		$html = $this->render_list(
+			array(
+				'list_type'      => 'posts',
+				'post_type'      => array( 'post' ),
+				'posts_per_page' => 10,
+				'orderby'        => 'title',
+				'order'          => 'ASC',
+				'template'       => '<ul>[posts]<li class="[post_class]"><a href="[post_permalink]">[post_title]</a> <span>[post_excerpt]</span></li>[/posts]</ul>',
+			)
+		);
+		$this->assertMatchesHtmlSnapshot( 'posts-custom', $html );
+	}
+
+	public function test_posts_grouped_by_year() {
+		$html = $this->render_list(
+			array(
+				'list_type'      => 'posts',
+				'post_type'      => array( 'post' ),
+				'posts_per_page' => 10,
+				'orderby'        => 'post_date',
+				'order'          => 'DESC',
+				'groupby'        => 'year',
+				'template'       => '<ul>[groups]<li><strong>[group_title]</strong><ol>[posts]<li><a href="[post_permalink]">[post_title]</a></li>[/posts]</ol></li>[/groups]</ul>',
+			)
+		);
+		$this->assertMatchesHtmlSnapshot( 'posts-grouped-year', $html );
+	}
+
+	public function test_posts_pagination() {
+		$html = $this->render_list(
+			array(
+				'list_type'      => 'posts',
+				'post_type'      => array( 'post' ),
+				'posts_per_page' => 2,
+				'orderby'        => 'post_date',
+				'order'          => 'DESC',
+				'template'       => '<ul>[posts]<li>[post_title]</li>[/posts]</ul>[nav type="plain"]',
+			)
+		);
+		$this->assertMatchesHtmlSnapshot( 'posts-pagination', $html );
+	}
+
+	public function test_terms_list_default_template() {
+		$html = $this->render_list(
+			array(
+				'list_type'      => 'terms',
+				'terms_taxonomy' => 'category',
+			)
+		);
+		$this->assertMatchesHtmlSnapshot( 'terms-default', $html );
+	}
+
+	public function test_terms_posts_list() {
+		$html = $this->render_list(
+			array(
+				'list_type'      => 'terms.posts',
+				'terms_taxonomy' => 'category',
+				'post_type'      => array( 'post' ),
+				'posts_per_page' => 10,
+				'orderby'        => 'post_date',
+				'order'          => 'DESC',
+			)
+		);
+		$this->assertMatchesHtmlSnapshot( 'terms-posts-default', $html );
+	}
+
+	public function test_users_list_default_template() {
+		$html = $this->render_list(
+			array(
+				'list_type' => 'users',
+			)
+		);
+		$this->assertMatchesHtmlSnapshot( 'users-default', $html );
+	}
+
+	public function test_users_posts_list() {
+		$html = $this->render_list(
+			array(
+				'list_type'      => 'users.posts',
+				'post_type'      => array( 'post' ),
+				'posts_per_page' => 10,
+				'orderby'        => 'post_date',
+				'order'          => 'DESC',
+			)
+		);
+		$this->assertMatchesHtmlSnapshot( 'users-posts-default', $html );
+	}
+
+	/**
+	 * Regression guard for the reported crash class: unit suffixes in
+	 * template tag attributes (post_thumbnail width="50px") must never fatal.
+	 */
+	public function test_thumbnail_tag_with_unit_suffix_attribute_does_not_fatal() {
+		$attachment_id = self::factory()->attachment->create_upload_object(
+			DIR_TESTDATA . '/images/canola.jpg',
+			self::$post_ids[0]
+		);
+		set_post_thumbnail( self::$post_ids[0], $attachment_id );
+
+		$html = $this->render_list(
+			array(
+				'list_type'      => 'posts',
+				'post_type'      => array( 'post' ),
+				'posts_per_page' => 10,
+				'template'       => '[posts]<div>[post_title] [post_thumbnail width="50px" height="50px"]</div>[/posts]',
+			)
+		);
+
+		$this->assertIsString( $html );
+		$this->assertStringContainsString( 'Winter release notes', $html );
+	}
+}

--- a/tests/ListRenderingTest.php
+++ b/tests/ListRenderingTest.php
@@ -258,5 +258,6 @@ class ListRenderingTest extends WP_UnitTestCase {
 
 		$this->assertIsString( $html );
 		$this->assertStringContainsString( 'Winter release notes', $html );
+		$this->assertStringContainsString( '<img', $html, 'Thumbnail should render despite the px-suffixed dimensions' );
 	}
 }

--- a/tests/OptionsVersionTest.php
+++ b/tests/OptionsVersionTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Options versioning and lazy migration behavior.
+ *
+ * @package W4_Post_List
+ */
+
+class OptionsVersionTest extends WP_UnitTestCase {
+
+	public function test_version_is_stamped_on_save_path() {
+		$options = apply_filters( 'w4pl/pre_save_options', array( 'list_type' => 'posts' ) );
+
+		$this->assertArrayHasKey( 'options_version', $options );
+		$this->assertSame( W4PL_Options_Migrator::OPTIONS_VERSION, $options['options_version'] );
+	}
+
+	public function test_legacy_options_are_migrated_on_read() {
+		$options = apply_filters( 'w4pl/pre_get_options', array( 'list_type' => 'posts' ) );
+
+		$this->assertSame( W4PL_Options_Migrator::OPTIONS_VERSION, $options['options_version'] );
+	}
+
+	public function test_migrator_passes_non_array_through_untouched() {
+		$migrator = new W4PL_Options_Migrator();
+
+		$this->assertFalse( $migrator->migrate( false ) );
+		$this->assertFalse( $migrator->stamp_version( false ) );
+	}
+
+	public function test_legacy_and_versioned_options_render_identically() {
+		self::factory()->post->create(
+			array(
+				'post_title' => 'Migration fixture post',
+				'post_date'  => '2025-05-05 05:05:05',
+			)
+		);
+
+		$base = array(
+			'id'             => 999999,
+			'list_type'      => 'posts',
+			'post_type'      => array( 'post' ),
+			'posts_per_page' => 10,
+			'orderby'        => 'post_date',
+			'order'          => 'DESC',
+		);
+
+		$legacy    = $base;
+		$versioned = $base;
+
+		$versioned['options_version'] = W4PL_Options_Migrator::OPTIONS_VERSION;
+
+		$legacy_html    = W4PL_List_Factory::get_list( apply_filters( 'w4pl/pre_get_options', $legacy ) )->get_html();
+		$versioned_html = W4PL_List_Factory::get_list( apply_filters( 'w4pl/pre_get_options', $versioned ) )->get_html();
+
+		$this->assertNotEmpty( $legacy_html );
+		$this->assertSame( $legacy_html, $versioned_html );
+	}
+}

--- a/tests/PluginLoadedTest.php
+++ b/tests/PluginLoadedTest.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Smoke test: the plugin bootstraps inside the test suite.
+ *
+ * @package W4_Post_List
+ */
+
+class PluginLoadedTest extends WP_UnitTestCase {
+
+	public function test_plugin_main_class_loaded() {
+		$this->assertTrue( class_exists( 'W4_Post_List' ) );
+		$this->assertTrue( defined( 'W4PL_VERSION' ) );
+	}
+
+	public function test_list_post_type_registered() {
+		$this->assertTrue( post_type_exists( 'w4pl' ) );
+	}
+
+	public function test_postlist_shortcode_registered() {
+		$this->assertTrue( shortcode_exists( 'postlist' ) );
+	}
+}

--- a/tests/StatsTest.php
+++ b/tests/StatsTest.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Usage counter behavior.
+ *
+ * @package W4_Post_List
+ */
+
+class StatsTest extends WP_UnitTestCase {
+
+	public function set_up() {
+		parent::set_up();
+		delete_option( W4PL_Stats::OPTION );
+	}
+
+	public function test_increment_and_get() {
+		W4PL_Stats::increment( 'sample_counter' );
+		W4PL_Stats::increment( 'sample_counter', 2 );
+
+		$this->assertSame( 3, W4PL_Stats::get( 'sample_counter' ) );
+		$this->assertSame( 0, W4PL_Stats::get( 'unknown_counter' ) );
+	}
+
+	public function test_publishing_a_list_increments_counters() {
+		self::factory()->post->create(
+			array(
+				'post_type'   => 'w4pl',
+				'post_status' => 'publish',
+			)
+		);
+
+		$this->assertSame( 1, W4PL_Stats::get( 'lists_created' ) );
+		$this->assertSame( 1, W4PL_Stats::get( 'lists_published' ) );
+	}
+
+	public function test_draft_then_publish_counts_creation_once() {
+		$id = self::factory()->post->create(
+			array(
+				'post_type'   => 'w4pl',
+				'post_status' => 'draft',
+			)
+		);
+
+		$this->assertSame( 1, W4PL_Stats::get( 'lists_created' ) );
+		$this->assertSame( 0, W4PL_Stats::get( 'lists_published' ) );
+
+		wp_publish_post( $id );
+
+		$this->assertSame( 1, W4PL_Stats::get( 'lists_created' ) );
+		$this->assertSame( 1, W4PL_Stats::get( 'lists_published' ) );
+	}
+
+	public function test_regular_posts_do_not_count() {
+		self::factory()->post->create( array( 'post_status' => 'publish' ) );
+
+		$this->assertSame( 0, W4PL_Stats::get( 'lists_created' ) );
+	}
+
+	public function test_counters_reach_insights_extra() {
+		W4PL_Stats::increment( 'lists_created', 5 );
+
+		$extra = w4pl_insights_extra();
+
+		$this->assertSame( 5, $extra['Stat_lists_created'] );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * PHPUnit bootstrap: loads the WP test suite (wp-phpunit) with this plugin active.
+ *
+ * @package W4_Post_List
+ */
+
+require_once dirname( __DIR__ ) . '/vendor-dev/autoload.php';
+
+$w4pl_tests_dir = getenv( 'WP_PHPUNIT__DIR' );
+if ( ! $w4pl_tests_dir ) {
+	$w4pl_tests_dir = dirname( __DIR__ ) . '/vendor-dev/wp-phpunit/wp-phpunit';
+}
+
+putenv( 'WP_PHPUNIT__TESTS_CONFIG=' . __DIR__ . '/wp-tests-config.php' );
+
+require_once $w4pl_tests_dir . '/includes/functions.php';
+
+tests_add_filter(
+	'muplugins_loaded',
+	function () {
+		require dirname( __DIR__ ) . '/w4-post-list.php';
+	}
+);
+
+require $w4pl_tests_dir . '/includes/bootstrap.php';

--- a/tests/snapshots/posts-custom.html
+++ b/tests/snapshots/posts-custom.html
@@ -1,0 +1,7 @@
+<!--W4PL_List_{ID}-->
+<div id="w4pl-list-{ID}" class="w4pl">
+	<div id="w4pl-inner-{ID}" class="w4pl-inner">
+		<ul><li class="post-{ID} post type-post status-publish format-standard hentry category-beta"><a href="http://example.org/?p={ID}">Hello from the archive</a> <span>Excerpt for Hello from the archive.</span></li><li class="post-{ID} post type-post status-publish format-standard hentry category-beta"><a href="http://example.org/?p={ID}">Interview with a builder</a> <span>Excerpt for Interview with a builder.</span></li><li class="post-{ID} post type-post status-publish format-standard hentry category-beta"><a href="http://example.org/?p={ID}">Spring cleaning tips</a> <span>Excerpt for Spring cleaning tips.</span></li><li class="post-{ID} post type-post status-publish format-standard hentry category-alpha"><a href="http://example.org/?p={ID}">Ten tips for faster sites</a> <span>Excerpt for Ten tips for faster sites.</span></li><li class="post-{ID} post type-post status-publish format-standard hentry category-alpha"><a href="http://example.org/?p={ID}">Winter release notes</a> <span>Excerpt for Winter release notes.</span></li><li class="post-{ID} post type-post status-publish format-standard hentry category-alpha"><a href="http://example.org/?p={ID}">Year in review</a> <span>Excerpt for Year in review.</span></li></ul>
+	</div><!--#w4pl-inner-{ID}-->
+</div><!--#w4pl-{ID}-->
+<!--END_W4PL_List_{ID}-->

--- a/tests/snapshots/posts-default.html
+++ b/tests/snapshots/posts-default.html
@@ -1,0 +1,43 @@
+<!--W4PL_List_{ID}-->
+<div id="w4pl-list-{ID}" class="w4pl">
+	<div id="w4pl-inner-{ID}" class="w4pl-inner">
+		<ul>
+<li>
+<a class="post_title w4pl_post_title" href="http://example.org/?p={ID}" title="View Spring cleaning tips">Spring cleaning tips</a>
+<div class="post-excerpt">Excerpt for Spring cleaning tips.</div>
+<a class="read_more" href="http://example.org/?p={ID}" title="Continue reading &raquo; Spring cleaning tips">Continue reading &raquo;</a>
+</li>
+
+<li>
+<a class="post_title w4pl_post_title" href="http://example.org/?p={ID}" title="View Winter release notes">Winter release notes</a>
+<div class="post-excerpt">Excerpt for Winter release notes.</div>
+<a class="read_more" href="http://example.org/?p={ID}" title="Continue reading &raquo; Winter release notes">Continue reading &raquo;</a>
+</li>
+
+<li>
+<a class="post_title w4pl_post_title" href="http://example.org/?p={ID}" title="View Year in review">Year in review</a>
+<div class="post-excerpt">Excerpt for Year in review.</div>
+<a class="read_more" href="http://example.org/?p={ID}" title="Continue reading &raquo; Year in review">Continue reading &raquo;</a>
+</li>
+
+<li>
+<a class="post_title w4pl_post_title" href="http://example.org/?p={ID}" title="View Interview with a builder">Interview with a builder</a>
+<div class="post-excerpt">Excerpt for Interview with a builder.</div>
+<a class="read_more" href="http://example.org/?p={ID}" title="Continue reading &raquo; Interview with a builder">Continue reading &raquo;</a>
+</li>
+
+<li>
+<a class="post_title w4pl_post_title" href="http://example.org/?p={ID}" title="View Ten tips for faster sites">Ten tips for faster sites</a>
+<div class="post-excerpt">Excerpt for Ten tips for faster sites.</div>
+<a class="read_more" href="http://example.org/?p={ID}" title="Continue reading &raquo; Ten tips for faster sites">Continue reading &raquo;</a>
+</li>
+
+<li>
+<a class="post_title w4pl_post_title" href="http://example.org/?p={ID}" title="View Hello from the archive">Hello from the archive</a>
+<div class="post-excerpt">Excerpt for Hello from the archive.</div>
+<a class="read_more" href="http://example.org/?p={ID}" title="Continue reading &raquo; Hello from the archive">Continue reading &raquo;</a>
+</li>
+</ul>
+	</div><!--#w4pl-inner-{ID}-->
+</div><!--#w4pl-{ID}-->
+<!--END_W4PL_List_{ID}-->

--- a/tests/snapshots/posts-grouped-year.html
+++ b/tests/snapshots/posts-grouped-year.html
@@ -1,0 +1,7 @@
+<!--W4PL_List_{ID}-->
+<div id="w4pl-list-{ID}" class="w4pl">
+	<div id="w4pl-inner-{ID}" class="w4pl-inner">
+		<ul><li><strong>2026</strong><ol><li><a href="http://example.org/?p={ID}">Spring cleaning tips</a></li><li><a href="http://example.org/?p={ID}">Winter release notes</a></li></ol></li><li><strong>2025</strong><ol><li><a href="http://example.org/?p={ID}">Year in review</a></li><li><a href="http://example.org/?p={ID}">Interview with a builder</a></li></ol></li><li><strong>2024</strong><ol><li><a href="http://example.org/?p={ID}">Ten tips for faster sites</a></li><li><a href="http://example.org/?p={ID}">Hello from the archive</a></li></ol></li></ul>
+	</div><!--#w4pl-inner-{ID}-->
+</div><!--#w4pl-{ID}-->
+<!--END_W4PL_List_{ID}-->

--- a/tests/snapshots/posts-pagination.html
+++ b/tests/snapshots/posts-pagination.html
@@ -1,0 +1,10 @@
+<!--W4PL_List_{ID}-->
+<div id="w4pl-list-{ID}" class="w4pl">
+	<div id="w4pl-inner-{ID}" class="w4pl-inner">
+		<ul><li>Spring cleaning tips</li><li>Winter release notes</li></ul><div class="navigation"><span aria-current="page" class="page-numbers current">1</span>
+<a class="page-numbers" href="http://example.org/?page{ID}=2">2</a>
+<a class="page-numbers" href="http://example.org/?page{ID}=3">3</a>
+<a class="next page-numbers" href="http://example.org/?page{ID}=2">Next</a></div>
+	</div><!--#w4pl-inner-{ID}-->
+</div><!--#w4pl-{ID}-->
+<!--END_W4PL_List_{ID}-->

--- a/tests/snapshots/terms-default.html
+++ b/tests/snapshots/terms-default.html
@@ -1,0 +1,19 @@
+<!--W4PL_List 14-->
+<div id="w4pl-list-{ID}" class="w4pl">
+	<div id="w4pl-inner-{ID}" class="w4pl-inner">
+		<ul>
+<li>
+<a href="http://example.org/?cat={ID}">Alpha</a>
+</li>
+
+<li>
+<a href="http://example.org/?cat={ID}">Beta</a>
+</li>
+
+<li>
+<a href="http://example.org/?cat={ID}">Uncategorized</a>
+</li>
+</ul>
+	</div><!--#w4pl-inner-{ID}-->
+</div><!--#w4pl-{ID}-->
+<!--end W4PL_List 14-->

--- a/tests/snapshots/terms-posts-default.html
+++ b/tests/snapshots/terms-posts-default.html
@@ -1,0 +1,58 @@
+<!--W4PL_List_{ID}-->
+<div id="w4pl-list-{ID}" class="w4pl">
+	<div id="w4pl-inner-{ID}" class="w4pl-inner">
+		<ul>
+<li>
+<a href="http://example.org/?cat={ID}">Alpha</a>
+<ul>
+<li>
+<a class="post_title w4pl_post_title" href="http://example.org/?p={ID}" title="View Winter release notes">Winter release notes</a>
+<div class="post-excerpt">Excerpt for Winter release notes.</div>
+<a class="read_more" href="http://example.org/?p={ID}" title="Continue reading &raquo; Winter release notes">Continue reading &raquo;</a>
+</li>
+
+<li>
+<a class="post_title w4pl_post_title" href="http://example.org/?p={ID}" title="View Year in review">Year in review</a>
+<div class="post-excerpt">Excerpt for Year in review.</div>
+<a class="read_more" href="http://example.org/?p={ID}" title="Continue reading &raquo; Year in review">Continue reading &raquo;</a>
+</li>
+
+<li>
+<a class="post_title w4pl_post_title" href="http://example.org/?p={ID}" title="View Ten tips for faster sites">Ten tips for faster sites</a>
+<div class="post-excerpt">Excerpt for Ten tips for faster sites.</div>
+<a class="read_more" href="http://example.org/?p={ID}" title="Continue reading &raquo; Ten tips for faster sites">Continue reading &raquo;</a>
+</li>
+</ul>
+</li>
+
+<li>
+<a href="http://example.org/?cat={ID}">Beta</a>
+<ul>
+<li>
+<a class="post_title w4pl_post_title" href="http://example.org/?p={ID}" title="View Spring cleaning tips">Spring cleaning tips</a>
+<div class="post-excerpt">Excerpt for Spring cleaning tips.</div>
+<a class="read_more" href="http://example.org/?p={ID}" title="Continue reading &raquo; Spring cleaning tips">Continue reading &raquo;</a>
+</li>
+
+<li>
+<a class="post_title w4pl_post_title" href="http://example.org/?p={ID}" title="View Interview with a builder">Interview with a builder</a>
+<div class="post-excerpt">Excerpt for Interview with a builder.</div>
+<a class="read_more" href="http://example.org/?p={ID}" title="Continue reading &raquo; Interview with a builder">Continue reading &raquo;</a>
+</li>
+
+<li>
+<a class="post_title w4pl_post_title" href="http://example.org/?p={ID}" title="View Hello from the archive">Hello from the archive</a>
+<div class="post-excerpt">Excerpt for Hello from the archive.</div>
+<a class="read_more" href="http://example.org/?p={ID}" title="Continue reading &raquo; Hello from the archive">Continue reading &raquo;</a>
+</li>
+</ul>
+</li>
+
+<li>
+<a href="http://example.org/?cat={ID}">Uncategorized</a>
+<ul></ul>
+</li>
+</ul>
+	</div><!--#w4pl-inner-{ID}-->
+</div><!--#w4pl-{ID}-->
+<!--END_W4PL_List_{ID}-->

--- a/tests/snapshots/users-default.html
+++ b/tests/snapshots/users-default.html
@@ -1,0 +1,19 @@
+<!--W4PL_List_{ID}-->
+<div id="w4pl-list-{ID}" class="w4pl">
+	<div id="w4pl-inner-{ID}" class="w4pl-inner">
+		<ul>
+<li>
+<a href="http://example.org/?author={ID}">Bob Builder</a>
+</li>
+
+<li>
+<a href="http://example.org/?author={ID}">Ann Author</a>
+</li>
+
+<li>
+<a href="http://example.org/?author={ID}">admin</a>
+</li>
+</ul>
+	</div><!--#w4pl-inner-{ID}-->
+</div><!--#w4pl-{ID}-->
+<!--END_W4PL_List_{ID}-->

--- a/tests/snapshots/users-posts-default.html
+++ b/tests/snapshots/users-posts-default.html
@@ -1,0 +1,58 @@
+<!--W4PL_List_{ID}-->
+<div id="w4pl-list-{ID}" class="w4pl">
+	<div id="w4pl-inner-{ID}" class="w4pl-inner">
+		<ul>
+<li>
+<a href="http://example.org/?author={ID}">Bob Builder</a>
+<ul>
+<li>
+<a class="post_title w4pl_post_title" href="http://example.org/?p={ID}" title="View Spring cleaning tips">Spring cleaning tips</a>
+<div class="post-excerpt">Excerpt for Spring cleaning tips.</div>
+<a class="read_more" href="http://example.org/?p={ID}" title="Continue reading &raquo; Spring cleaning tips">Continue reading &raquo;</a>
+</li>
+
+<li>
+<a class="post_title w4pl_post_title" href="http://example.org/?p={ID}" title="View Interview with a builder">Interview with a builder</a>
+<div class="post-excerpt">Excerpt for Interview with a builder.</div>
+<a class="read_more" href="http://example.org/?p={ID}" title="Continue reading &raquo; Interview with a builder">Continue reading &raquo;</a>
+</li>
+
+<li>
+<a class="post_title w4pl_post_title" href="http://example.org/?p={ID}" title="View Hello from the archive">Hello from the archive</a>
+<div class="post-excerpt">Excerpt for Hello from the archive.</div>
+<a class="read_more" href="http://example.org/?p={ID}" title="Continue reading &raquo; Hello from the archive">Continue reading &raquo;</a>
+</li>
+</ul>
+</li>
+
+<li>
+<a href="http://example.org/?author={ID}">Ann Author</a>
+<ul>
+<li>
+<a class="post_title w4pl_post_title" href="http://example.org/?p={ID}" title="View Winter release notes">Winter release notes</a>
+<div class="post-excerpt">Excerpt for Winter release notes.</div>
+<a class="read_more" href="http://example.org/?p={ID}" title="Continue reading &raquo; Winter release notes">Continue reading &raquo;</a>
+</li>
+
+<li>
+<a class="post_title w4pl_post_title" href="http://example.org/?p={ID}" title="View Year in review">Year in review</a>
+<div class="post-excerpt">Excerpt for Year in review.</div>
+<a class="read_more" href="http://example.org/?p={ID}" title="Continue reading &raquo; Year in review">Continue reading &raquo;</a>
+</li>
+
+<li>
+<a class="post_title w4pl_post_title" href="http://example.org/?p={ID}" title="View Ten tips for faster sites">Ten tips for faster sites</a>
+<div class="post-excerpt">Excerpt for Ten tips for faster sites.</div>
+<a class="read_more" href="http://example.org/?p={ID}" title="Continue reading &raquo; Ten tips for faster sites">Continue reading &raquo;</a>
+</li>
+</ul>
+</li>
+
+<li>
+<a href="http://example.org/?author={ID}">admin</a>
+<ul></ul>
+</li>
+</ul>
+	</div><!--#w4pl-inner-{ID}-->
+</div><!--#w4pl-{ID}-->
+<!--END_W4PL_List_{ID}-->

--- a/tests/wp-tests-config.php
+++ b/tests/wp-tests-config.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * WordPress test suite configuration, environment-driven.
+ *
+ * Local (docker): WP_TESTS_DB_HOST=w4pl_mysql etc. are passed by the runner.
+ * CI: a mysql service on 127.0.0.1 with the credentials below as defaults.
+ *
+ * @package W4_Post_List
+ */
+
+$w4pl_root = dirname( __DIR__ );
+
+define( 'ABSPATH', ( getenv( 'WP_ABSPATH' ) ? getenv( 'WP_ABSPATH' ) : $w4pl_root . '/wp' ) . '/' );
+
+define( 'DB_NAME', getenv( 'WP_TESTS_DB_NAME' ) ? getenv( 'WP_TESTS_DB_NAME' ) : 'w4pl_tests' );
+define( 'DB_USER', getenv( 'WP_TESTS_DB_USER' ) ? getenv( 'WP_TESTS_DB_USER' ) : 'root' );
+define( 'DB_PASSWORD', getenv( 'WP_TESTS_DB_PASSWORD' ) ? getenv( 'WP_TESTS_DB_PASSWORD' ) : 'root' );
+define( 'DB_HOST', getenv( 'WP_TESTS_DB_HOST' ) ? getenv( 'WP_TESTS_DB_HOST' ) : '127.0.0.1' );
+define( 'DB_CHARSET', 'utf8' );
+define( 'DB_COLLATE', '' );
+
+$table_prefix = 'wptests_';
+
+define( 'WP_TESTS_DOMAIN', 'example.org' );
+define( 'WP_TESTS_EMAIL', 'admin@example.org' );
+define( 'WP_TESTS_TITLE', 'Test Blog' );
+define( 'WP_PHP_BINARY', 'php' );
+define( 'WP_DEBUG', true );

--- a/w4-post-list.php
+++ b/w4-post-list.php
@@ -3,7 +3,7 @@
  * Plugin Name: W4 Post List
  * Plugin URI: https://w4dev.com/plugins/w4-post-list
  * Description: Create lists of posts, terms and users — grouped archives, taxonomy indexes and user directories — placed anywhere with the block, [postlist] shortcode or widget.
- * Version: 2.5.9
+ * Version: 2.6.0
  * Requires at least: 5.8
  * Requires PHP: 7.4
  * Author: Shazzad Hossain Khan


### PR DESCRIPTION
## Summary
- **Characterization test suite** (24 tests, 66 assertions, verified green locally in the docker env): snapshot tests freeze the rendered HTML of all five list types plus grouped-by-year and pagination — the compatibility contract for ~2k sites' stored lists. Any refactor that changes a snapshot is now a visible, deliberate act.
- **Docs-drift guard**: doc examples, default templates, and preset templates are diffed against the registered template-tag list in CI — the 2.5.8 broken-examples bug class can't regress silently.
- **Crash-class regression test**: `[post_thumbnail width="50px"]` (the long-unanswered support thread) proven not to fatal with a real attachment fixture.
- **Options versioning**: `_w4pl` now carries `options_version` (stamped on save, lazily migrated on read at priority 1 on `w4pl/pre_get_options`, mirroring the existing 1.6.7 shim). Snapshot tests prove versioned and legacy options render byte-identically.
- **Opt-in telemetry counters**: `W4PL_Stats` (lists_created/lists_published) rides the existing Appsero insights ping — nothing sent without the user's existing opt-in.
- **CI**: PHPUnit matrix on PHP 7.4 + 8.2 (readme's minimum and modern) with mysql service; **the SVN deploy job now `needs: test`** — a tag can no longer ship unverified. phpcs runs as an advisory job (the legacy codebase has ~2000 pre-existing WPCS 3.x violations; a mass phpcbf cleanup is deliberately out of scope for this release — new M3 files pass clean).
- **PHP 8.2 fix**: `#[AllowDynamicProperties]` on the abstract query class (comment on PHP <8.0) removes dynamic-property deprecation spam.
- Dev tooling isolated in `composer-dev.json` → gitignored `vendor-dev/` + `wp/`, keeping the committed/shipped `vendor/` untouched; all new paths added to `.distignore`.

## Test plan
- [x] Full suite green locally in docker (PHP 8.2): 24 tests, 66 assertions
- [x] Snapshots deterministic across regeneration + compare runs
- [x] New files pass phpcs clean
- [ ] CI green on this PR for both PHP 7.4 and 8.2 (first CI run — the 7.4 leg is the one to watch)
- [ ] After merge: deploy workflow shows test job gating the SVN deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)