### PR TITLE
v2.7.0: First-run onboarding — example list, welcome notice, empty state (M4)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,9 @@
 == Changelog ==
+= 2.7.0 =
+* New: First-run onboarding - fresh installs get a draft "Example: Recent Posts" list, so there is always a working configuration to open and learn from.
+* New: A dismissible "Get started" notice after activation walks through the three steps: create a list, publish, place it with the block or shortcode.
+* New: Helpful empty state on the Lists screen and a contextual Help tab on the list screens summarizing the workflow.
+* Improved: The telemetry opt-in prompt now waits until after your first published list, so guidance comes first.
 = 2.6.0 =
 * New: Automated test suite now gates every release - characterization snapshots freeze the rendered output of all five list types (including grouped lists and pagination) so updates can no longer break existing lists unnoticed.
 * New: List options now carry a schema version with a lazy migration path, protecting saved lists during future upgrades.

--- a/admin/class-admin-onboarding.php
+++ b/admin/class-admin-onboarding.php
@@ -1,0 +1,264 @@
+<?php
+/**
+ * First-run onboarding: sample list, welcome notice, empty state, help tabs.
+ *
+ * @class W4PL_Admin_Onboarding
+ * @package W4_Post_List
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Guides a new user from activation to a first working list.
+ */
+class W4PL_Admin_Onboarding {
+
+	/**
+	 * Constructor
+	 */
+	public function __construct() {
+		add_action( 'admin_init', array( $this, 'maybe_create_sample_list' ) );
+		add_action( 'admin_init', array( $this, 'maybe_dismiss_welcome' ) );
+		add_action( 'admin_notices', array( $this, 'welcome_notice' ) );
+		add_action( 'admin_notices', array( $this, 'empty_state' ) );
+		add_action( 'wp_ajax_w4pl_dismiss_welcome', array( $this, 'ajax_dismiss_welcome' ) );
+		add_action( 'current_screen', array( $this, 'help_tabs' ) );
+	}
+
+	/**
+	 * Create a draft example list on first install, so the Lists screen is
+	 * never empty and there is always a working configuration to learn from.
+	 */
+	public function maybe_create_sample_list() {
+		if ( ! get_option( 'w4pl_maybe_create_sample' ) ) {
+			return;
+		}
+
+		$counts = wp_count_posts( 'w4pl' );
+		$total  = array_sum( (array) $counts );
+
+		if ( $total > 0 ) {
+			delete_option( 'w4pl_maybe_create_sample' );
+			return;
+		}
+
+		// Wait for a user who can author lists; keep the flag until then.
+		if ( ! current_user_can( 'edit_pages' ) ) {
+			return;
+		}
+
+		delete_option( 'w4pl_maybe_create_sample' );
+
+		self::create_sample_list();
+	}
+
+	/**
+	 * Insert the example list through the same option pipeline the editor uses.
+	 *
+	 * @return int The list post ID.
+	 */
+	public static function create_sample_list() {
+		$templates = new W4PL_List_Templates();
+
+		$options = array(
+			'list_type'      => 'posts',
+			'post_type'      => array( 'post' ),
+			'post_status'    => array( 'publish' ),
+			'posts_per_page' => 5,
+			'orderby'        => 'post_date',
+			'order'          => 'DESC',
+			'template'       => $templates->sanitize_template( '', array( 'list_type' => 'posts' ) ),
+		);
+
+		$list_id = wp_insert_post(
+			array(
+				'post_type'   => 'w4pl',
+				'post_status' => 'draft',
+				'post_title'  => __( 'Example: Recent Posts', 'w4-post-list' ),
+			)
+		);
+
+		if ( ! $list_id || is_wp_error( $list_id ) ) {
+			return 0;
+		}
+
+		$options['id'] = $list_id;
+		$options       = apply_filters( 'w4pl/pre_save_options', $options );
+
+		update_post_meta( $list_id, '_w4pl', $options );
+
+		return $list_id;
+	}
+
+	/**
+	 * Dismissible "Get started" notice shown after activation.
+	 */
+	public function welcome_notice() {
+		if ( ! get_option( 'w4pl_welcome_pending' ) || ! current_user_can( 'edit_pages' ) ) {
+			return;
+		}
+
+		$screen = get_current_screen();
+		if ( ! $screen || ! in_array( $screen->id, array( 'dashboard', 'plugins', 'edit-w4pl', 'w4pl' ), true ) ) {
+			return;
+		}
+
+		$sample = get_posts(
+			array(
+				'post_type'   => 'w4pl',
+				'post_status' => 'any',
+				'numberposts' => 1,
+				'orderby'     => 'ID',
+				'order'       => 'ASC',
+			)
+		);
+
+		if ( ! empty( $sample ) ) {
+			$primary_url  = get_edit_post_link( $sample[0]->ID, 'url' );
+			$primary_text = __( 'Open the example list', 'w4-post-list' );
+		} else {
+			$primary_url  = admin_url( 'post-new.php?post_type=w4pl' );
+			$primary_text = __( 'Create your first list', 'w4-post-list' );
+		}
+
+		$docs_url    = admin_url( 'edit.php?post_type=w4pl&page=w4pl-docs' );
+		$dismiss_url = wp_nonce_url( add_query_arg( 'w4pl_dismiss_welcome', '1' ), 'w4pl_dismiss_welcome' );
+		?>
+		<div class="notice notice-info is-dismissible w4pl-welcome-notice">
+			<p>
+				<strong><?php esc_html_e( 'Welcome to W4 Post List — three steps to your first list:', 'w4-post-list' ); ?></strong>
+			</p>
+			<ol style="margin-top:0;">
+				<li><?php esc_html_e( 'Create a list (or open the ready-made example) and choose what it shows.', 'w4-post-list' ); ?></li>
+				<li><?php esc_html_e( 'Publish it.', 'w4-post-list' ); ?></li>
+				<li><?php esc_html_e( 'Place it on any page with the W4 Post List block, or paste its [postlist] shortcode.', 'w4-post-list' ); ?></li>
+			</ol>
+			<p>
+				<a class="button button-primary" href="<?php echo esc_url( $primary_url ); ?>"><?php echo esc_html( $primary_text ); ?></a>
+				<a class="button" href="<?php echo esc_url( $docs_url ); ?>"><?php esc_html_e( 'Read the guide', 'w4-post-list' ); ?></a>
+				<a href="<?php echo esc_url( $dismiss_url ); ?>" style="margin-left:8px;"><?php esc_html_e( 'Dismiss', 'w4-post-list' ); ?></a>
+			</p>
+		</div>
+		<script>
+		( function () {
+			var notice = document.querySelector( '.w4pl-welcome-notice' );
+			if ( ! notice ) {
+				return;
+			}
+			notice.addEventListener( 'click', function ( e ) {
+				if ( ! e.target.classList.contains( 'notice-dismiss' ) ) {
+					return;
+				}
+				var data = new FormData();
+				data.append( 'action', 'w4pl_dismiss_welcome' );
+				data.append( 'nonce', <?php echo wp_json_encode( wp_create_nonce( 'w4pl_dismiss_welcome' ) ); ?> );
+				fetch( ajaxurl, { method: 'POST', credentials: 'same-origin', body: data } );
+			} );
+		} )();
+		</script>
+		<?php
+	}
+
+	/**
+	 * No-JS dismiss fallback via nonce-checked GET parameter.
+	 */
+	public function maybe_dismiss_welcome() {
+		if ( ! isset( $_GET['w4pl_dismiss_welcome'] ) ) {
+			return;
+		}
+
+		if ( ! isset( $_GET['_wpnonce'] ) || ! wp_verify_nonce( sanitize_key( wp_unslash( $_GET['_wpnonce'] ) ), 'w4pl_dismiss_welcome' ) ) {
+			return;
+		}
+
+		if ( ! current_user_can( 'edit_pages' ) ) {
+			return;
+		}
+
+		delete_option( 'w4pl_welcome_pending' );
+
+		wp_safe_redirect( remove_query_arg( array( 'w4pl_dismiss_welcome', '_wpnonce' ) ) );
+		exit;
+	}
+
+	/**
+	 * Persist welcome-notice dismissal from the notice's X button.
+	 */
+	public function ajax_dismiss_welcome() {
+		check_ajax_referer( 'w4pl_dismiss_welcome', 'nonce' );
+
+		if ( ! current_user_can( 'edit_pages' ) ) {
+			wp_send_json_error();
+		}
+
+		delete_option( 'w4pl_welcome_pending' );
+
+		wp_send_json_success();
+	}
+
+	/**
+	 * Onboarding panel on the Lists screen when no lists exist.
+	 */
+	public function empty_state() {
+		$screen = get_current_screen();
+		if ( ! $screen || 'edit-w4pl' !== $screen->id ) {
+			return;
+		}
+
+		$counts = wp_count_posts( 'w4pl' );
+		if ( array_sum( (array) $counts ) > 0 ) {
+			return;
+		}
+		?>
+		<div class="notice notice-info">
+			<p>
+				<strong><?php esc_html_e( 'No lists yet.', 'w4-post-list' ); ?></strong>
+				<?php esc_html_e( 'A list is a saved query (posts, terms or users) plus a template that controls its HTML. Create one, publish it, then place it anywhere with the W4 Post List block or the [postlist] shortcode.', 'w4-post-list' ); ?>
+			</p>
+			<p>
+				<a class="button button-primary" href="<?php echo esc_url( admin_url( 'post-new.php?post_type=w4pl' ) ); ?>"><?php esc_html_e( 'Create your first list', 'w4-post-list' ); ?></a>
+				<a class="button" href="<?php echo esc_url( admin_url( 'edit.php?post_type=w4pl&page=w4pl-docs' ) ); ?>"><?php esc_html_e( 'Getting started guide', 'w4-post-list' ); ?></a>
+			</p>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Contextual Help tab on the list screens.
+	 *
+	 * @param WP_Screen $screen Current screen.
+	 */
+	public function help_tabs( $screen ) {
+		if ( ! $screen || ! in_array( $screen->id, array( 'w4pl', 'edit-w4pl' ), true ) ) {
+			return;
+		}
+
+		ob_start();
+		?>
+		<p><strong><?php esc_html_e( 'How W4 Post List works', 'w4-post-list' ); ?></strong></p>
+		<ol>
+			<li><?php esc_html_e( 'Create a list and pick a List Type (Posts, Terms, Users, or combined).', 'w4-post-list' ); ?></li>
+			<li><?php esc_html_e( 'Configure what to show in the section named after your list type. The advanced query sections are optional.', 'w4-post-list' ); ?></li>
+			<li><?php esc_html_e( 'Publish. A default template is applied automatically; edit the Template section for full HTML control.', 'w4-post-list' ); ?></li>
+			<li><?php esc_html_e( 'Place the list with the W4 Post List block, its [postlist] shortcode (see the Shortcode column), or the widget.', 'w4-post-list' ); ?></li>
+		</ol>
+		<p><?php esc_html_e( 'If a list renders nothing: check it is Published, the shortcode ID matches, and the template keeps its loop tags.', 'w4-post-list' ); ?></p>
+		<?php
+		$content = ob_get_clean();
+
+		$screen->add_help_tab(
+			array(
+				'id'      => 'w4pl-overview',
+				'title'   => __( 'W4 Post List', 'w4-post-list' ),
+				'content' => $content,
+			)
+		);
+
+		$screen->set_help_sidebar(
+			'<p><strong>' . esc_html__( 'More help', 'w4-post-list' ) . '</strong></p>' .
+			'<p><a href="' . esc_url( admin_url( 'edit.php?post_type=w4pl&page=w4pl-docs' ) ) . '">' . esc_html__( 'Documentation', 'w4-post-list' ) . '</a></p>'
+		);
+	}
+}

--- a/admin/pages/views/html-getting-started.php
+++ b/admin/pages/views/html-getting-started.php
@@ -22,6 +22,7 @@
 			'<a href="' . esc_url( admin_url( 'post-new.php?post_type=w4pl' ) ) . '">' . esc_html__( 'W4 Post List &rarr; Add New', 'w4-post-list' ) . '</a>'
 		);
 		?>
+		<?php esc_html_e( 'Fresh installs include a draft "Example: Recent Posts" list — open it to see a working configuration you can learn from or adapt.', 'w4-post-list' ); ?>
 	</p>
 
 	<h3>

--- a/appsero.php
+++ b/appsero.php
@@ -54,6 +54,13 @@ function w4pl_appsero_admin_notices() {
 		return;
 	}
 
+	// Hold the telemetry ask until the user has published a first list, so
+	// onboarding guidance is the plugin's first communication.
+	$published = wp_count_posts( 'w4pl' );
+	if ( empty( $published->publish ) ) {
+		return;
+	}
+
 	if (
 		( in_array( $pagenow, [ 'edit.php' ], true ) && 'w4pl' === $typenow )
 	) {

--- a/includes/class-w4-post-list.php
+++ b/includes/class-w4-post-list.php
@@ -29,7 +29,7 @@ final class W4_Post_List {
 	 *
 	 * @var string
 	 */
-	public $version = '2.6.0';
+	public $version = '2.7.0';
 
 	/**
 	 * This will hold current class instance
@@ -129,6 +129,7 @@ final class W4_Post_List {
 			include W4PL_DIR . '/admin/class-admin-lists-table-columns.php';
 			include W4PL_DIR . '/admin/class-admin-lists-metaboxes.php';
 			include W4PL_DIR . '/admin/class-admin-list-editor.php';
+			include W4PL_DIR . '/admin/class-admin-onboarding.php';
 
 			/* Admin pages */
 			foreach ( glob( W4PL_DIR . 'admin/pages/*.php' ) as $file ) {
@@ -169,6 +170,7 @@ final class W4_Post_List {
 			new W4PL_Admin_Main();
 			new W4PL_Admin_Lists_Table_Columns();
 			new W4PL_Admin_Lists_Metaboxes();
+			new W4PL_Admin_Onboarding();
 
 			new W4PL_Admin_Page_Docs();
 		}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "w4-post-list",
-	"version": "2.6.0",
+	"version": "2.7.0",
 	"description": "A WordPress Plugin for listing posts in some handy manner.",
 	"main": "Gruntfile.js",
 	"scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: post list, user list, post grid, category list, shortcode
 Requires at least: 5.8
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 2.6.0
+Stable tag: 2.7.0
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -116,6 +116,11 @@ In your admin: **W4 Post List → Documentation** (template tags reference, exam
 
 
 == Changelog ==
+= 2.7.0 =
+* New: First-run onboarding - fresh installs get a draft "Example: Recent Posts" list, so there is always a working configuration to open and learn from.
+* New: A dismissible "Get started" notice after activation walks through the three steps: create a list, publish, place it with the block or shortcode.
+* New: Helpful empty state on the Lists screen and a contextual Help tab on the list screens summarizing the workflow.
+* Improved: The telemetry opt-in prompt now waits until after your first published list, so guidance comes first.
 = 2.6.0 =
 * New: Automated test suite now gates every release - characterization snapshots freeze the rendered output of all five list types (including grouped lists and pagination) so updates can no longer break existing lists unnoticed.
 * New: List options now carry a schema version with a lazy migration path, protecting saved lists during future upgrades.
@@ -152,6 +157,8 @@ In your admin: **W4 Post List → Documentation** (template tags reference, exam
 [See changelog of all versions](https://raw.githubusercontent.com/w4devInc/w4-post-list/master/CHANGELOG.txt).
 
 == Upgrade Notice ==
+= 2.7.0 =
+First-run onboarding (example list, get-started guide), the post_thumbnail px-dimension fix, PHP 8.2 cleanups, and automated release testing.
 = 2.6.0 =
 Adds automated release testing, options versioning and PHP 8.2 deprecation fixes. No changes to list output.
 = 2.5.9 =

--- a/tests/OnboardingTest.php
+++ b/tests/OnboardingTest.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * First-run onboarding behavior.
+ *
+ * @package W4_Post_List
+ */
+
+class OnboardingTest extends WP_UnitTestCase {
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		// Admin-only class is not loaded by the plugin bootstrap in CLI context.
+		require_once dirname( __DIR__ ) . '/admin/class-admin-onboarding.php';
+	}
+
+	public function set_up() {
+		parent::set_up();
+
+		delete_option( 'w4pl_welcome_pending' );
+		delete_option( 'w4pl_maybe_create_sample' );
+
+		if ( ! function_exists( 'set_current_screen' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/class-wp-screen.php';
+			require_once ABSPATH . 'wp-admin/includes/screen.php';
+		}
+	}
+
+	public function test_activation_sets_onboarding_flags() {
+		w4pl_activated();
+
+		$this->assertNotEmpty( get_option( 'w4pl_welcome_pending' ) );
+		$this->assertNotEmpty( get_option( 'w4pl_maybe_create_sample' ) );
+	}
+
+	public function test_network_wide_activation_skips_onboarding_flags() {
+		w4pl_activated( true );
+
+		$this->assertEmpty( get_option( 'w4pl_welcome_pending' ) );
+		$this->assertEmpty( get_option( 'w4pl_maybe_create_sample' ) );
+	}
+
+	public function test_sample_list_is_created_and_renders() {
+		self::factory()->post->create( array( 'post_title' => 'Onboarding fixture post' ) );
+
+		$list_id = W4PL_Admin_Onboarding::create_sample_list();
+
+		$this->assertGreaterThan( 0, $list_id );
+
+		$list = get_post( $list_id );
+		$this->assertSame( 'w4pl', $list->post_type );
+		$this->assertSame( 'draft', $list->post_status );
+
+		$options = get_post_meta( $list_id, '_w4pl', true );
+		$this->assertSame( 'posts', $options['list_type'] );
+		$this->assertNotEmpty( $options['template'], 'Sample list must ship with a visible, editable template' );
+		$this->assertArrayHasKey( 'options_version', $options, 'Sample must go through the versioned save pipeline' );
+
+		$html = do_shortcode( '[postlist id="' . $list_id . '"]' );
+		$this->assertStringContainsString( 'Onboarding fixture post', $html, 'Sample list must actually render' );
+	}
+
+	public function test_sample_not_created_when_lists_exist() {
+		self::factory()->post->create( array( 'post_type' => 'w4pl' ) );
+		update_option( 'w4pl_maybe_create_sample', 1 );
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		$onboarding = new W4PL_Admin_Onboarding();
+		$onboarding->maybe_create_sample_list();
+
+		$counts = wp_count_posts( 'w4pl' );
+		$this->assertSame( 1, array_sum( (array) $counts ), 'No sample should be added next to existing lists' );
+		$this->assertEmpty( get_option( 'w4pl_maybe_create_sample' ), 'Flag should be cleared' );
+	}
+
+	public function test_sample_creation_waits_for_capable_user() {
+		update_option( 'w4pl_maybe_create_sample', 1 );
+		wp_set_current_user( 0 );
+
+		$onboarding = new W4PL_Admin_Onboarding();
+		$onboarding->maybe_create_sample_list();
+
+		$this->assertNotEmpty( get_option( 'w4pl_maybe_create_sample' ), 'Flag must survive until a capable user visits' );
+		$this->assertSame( 0, array_sum( (array) wp_count_posts( 'w4pl' ) ) );
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		$onboarding->maybe_create_sample_list();
+
+		$this->assertEmpty( get_option( 'w4pl_maybe_create_sample' ) );
+		$this->assertSame( 1, array_sum( (array) wp_count_posts( 'w4pl' ) ) );
+	}
+
+	public function test_welcome_notice_renders_only_when_pending() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		set_current_screen( 'dashboard' );
+
+		$onboarding = new W4PL_Admin_Onboarding();
+
+		ob_start();
+		$onboarding->welcome_notice();
+		$this->assertSame( '', ob_get_clean(), 'No notice without the pending flag' );
+
+		update_option( 'w4pl_welcome_pending', time() );
+
+		ob_start();
+		$onboarding->welcome_notice();
+		$html = ob_get_clean();
+
+		$this->assertStringContainsString( 'Welcome to W4 Post List', $html );
+		$this->assertStringContainsString( 'w4pl_dismiss_welcome', $html, 'Dismiss affordance present' );
+	}
+
+	public function test_empty_state_renders_only_with_zero_lists() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		set_current_screen( 'edit-w4pl' );
+
+		$onboarding = new W4PL_Admin_Onboarding();
+
+		ob_start();
+		$onboarding->empty_state();
+		$this->assertStringContainsString( 'No lists yet', ob_get_clean() );
+
+		self::factory()->post->create( array( 'post_type' => 'w4pl' ) );
+
+		ob_start();
+		$onboarding->empty_state();
+		$this->assertSame( '', ob_get_clean(), 'No empty-state once a list exists' );
+	}
+
+	public function test_help_tab_added_on_list_screens() {
+		set_current_screen( 'edit-w4pl' );
+		$screen = get_current_screen();
+
+		$onboarding = new W4PL_Admin_Onboarding();
+		$onboarding->help_tabs( $screen );
+
+		$this->assertNotNull( $screen->get_help_tab( 'w4pl-overview' ) );
+	}
+
+	public function test_appsero_notice_silent_before_first_published_list() {
+		global $pagenow, $typenow;
+		$pagenow = 'edit.php';
+		$typenow = 'w4pl';
+
+		ob_start();
+		w4pl_appsero_admin_notices();
+		$this->assertSame( '', ob_get_clean(), 'Telemetry ask must wait for the first published list' );
+	}
+}

--- a/w4-post-list.php
+++ b/w4-post-list.php
@@ -3,7 +3,7 @@
  * Plugin Name: W4 Post List
  * Plugin URI: https://w4dev.com/plugins/w4-post-list
  * Description: Create lists of posts, terms and users — grouped archives, taxonomy indexes and user directories — placed anywhere with the block, [postlist] shortcode or widget.
- * Version: 2.6.0
+ * Version: 2.7.0
  * Requires at least: 5.8
  * Requires PHP: 7.4
  * Author: Shazzad Hossain Khan
@@ -50,9 +50,18 @@ add_action( 'plugins_loaded', 'w4pl_load', 10 );
 
 /**
  * Run when plugin gets activated
+ *
+ * @param bool $network_wide Whether the plugin is being activated network-wide.
  */
-function w4pl_activated() {
+function w4pl_activated( $network_wide = false ) {
 	update_option( 'w4pl_flush_rules', time() );
+
+	// Per-site onboarding; skipped on network-wide activation so bulk
+	// activation does not touch every site.
+	if ( ! $network_wide ) {
+		update_option( 'w4pl_welcome_pending', time(), false );
+		update_option( 'w4pl_maybe_create_sample', 1, false );
+	}
 }
 register_activation_hook( W4PL_PLUGIN_FILE, 'w4pl_activated' );
 


### PR DESCRIPTION
## Summary
- **Draft "Example: Recent Posts" list on first install** — created on the first capable admin visit when zero lists exist (waits for a user with `edit_pages`; skipped on network-wide activation). Built through the same versioned save pipeline as the editor, so it carries `options_version` and an explicit editable template. The Lists screen is never an unexplained blank for new users.
- **Dismissible "Get started" notice** on the dashboard, plugins and list screens: the 3-step flow (create → publish → place), with "Open the example list" as the primary CTA and a docs link. Dismissal persists via a nonce-checked ajax endpoint, with a no-JS nonce-URL fallback.
- **Empty-state panel** on the Lists screen (explains what a list is + CTA + docs) and a **contextual Help tab** with help sidebar on both w4pl screens.
- **Appsero opt-in deferred** until a first list is published — onboarding guidance is now the plugin's first communication, not the telemetry ask. Sites that already have published lists keep seeing it as before.
- Getting Started docs updated to mention the example list; this release also ships the previously-merged 2.6.0 content (test suite + deploy gate, options versioning, `post_thumbnail width="50px"` fix, PHP 8.2 cleanups).

## Test plan
- [x] 33 tests / 91 assertions green locally (9 new onboarding tests: activation flags, network-wide skip, sample created once + actually renders + version-stamped, capability wait, notice/empty-state render conditions, help tab, Appsero gate)
- [x] New file passes phpcs clean
- [ ] CI green on PHP 7.4 + 8.2
- [ ] Manual: activate on the dev site → welcome notice appears, example list exists as draft, opt-in notice absent until a list is published

🤖 Generated with [Claude Code](https://claude.com/claude-code)