### PR TITLE
v2.9.0: Starter templates — copy-on-select library of 8 layouts (M6)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,10 @@
 == Changelog ==
+= 2.9.0 =
+* New: "Start from a template" - pick from 8 ready-made layouts (simple list, thumbnail cards, title & date list, year archive, category index, category index with posts, user directory, authors with posts). Picking one copies editable markup and styles into the Template and Style fields and sets the options it needs, like Group by. Developers can add layouts via the w4pl/starter_templates filter.
+* Improved: Lists using a legacy preset keep working exactly as before; the legacy preset field only appears on those lists.
+* Improved: In-plugin docs updated for the new flow; new FAQ "Do I have to write the template myself?".
+* Fix: Guarded the editor form action URL against missing server variables (CLI contexts).
+* Dev: Select field values are now attribute-escaped in the form engine.
 = 2.8.0 =
 * New: The Template, CSS and JavaScript fields are now real code editors with syntax highlighting and line numbers; template tags insert at the cursor.
 * Improved: Default templates rewritten in the plain tag dialect with a visible per-item wrapper (div.post-item / .term-item / .user-item) and the [nav] pagination tag, so the loop structure is obvious at a glance. Applies to newly created lists; saved lists keep their stored template.

--- a/admin/class-admin-list-editor.php
+++ b/admin/class-admin-list-editor.php
@@ -35,6 +35,10 @@ class W4PL_List_Editor {
 			$options['no_items_text'] = __( 'No items found.', 'w4-post-list' );
 		}
 
+		// Copy-on-select: a starter template picked in the form is applied
+		// here, in the editor path only - never at render time.
+		$options = W4PL_Starter_Templates::apply( $options );
+
 		$this->options = apply_filters( 'w4pl/pre_get_options', $options );
 	}
 

--- a/admin/pages/views/html-getting-started.php
+++ b/admin/pages/views/html-getting-started.php
@@ -30,6 +30,7 @@
 	</h3>
 	<p>
 		<?php esc_html_e( 'Open the section named after your list type (for example "Posts") and pick the post type, how many items to show, and the order. The other sections (Tax Query, Meta Query, Date Query) are optional filters — you can skip them entirely for your first list.', 'w4-post-list' ); ?>
+		<?php esc_html_e( 'For a ready-made design, pick a layout from "Start from a template" — it copies editable markup and styles into the Template and Style sections and sets any options it needs (like Group by).', 'w4-post-list' ); ?>
 	</p>
 
 	<h3>

--- a/admin/pages/views/html-template-examples.php
+++ b/admin/pages/views/html-template-examples.php
@@ -16,6 +16,9 @@
 <h2>
 	<?php esc_html_e( 'Examples', 'w4-post-list' ); ?>
 </h2>
+<p>
+	<?php esc_html_e( 'Tip: the "Start from a template" picker in the list editor copies ready-made layouts like these (cards, archives, directories) straight into your Template and Style fields.', 'w4-post-list' ); ?>
+</p>
 <h3>
 	<?php esc_html_e( 'Post list', 'w4-post-list' ); ?>
 </h3>

--- a/assets/js/list-editor.js
+++ b/assets/js/list-editor.js
@@ -208,6 +208,13 @@
 			$('#w4pl_lo').remove();
 			publish.removeClass('disabled').prop('disabled', false);
 
+			/*
+			 * A picked starter template was never applied (the refresh died),
+			 * so clear the selection - otherwise a later save would apply it
+			 * over the user's manual edits, contradicting the message below.
+			 */
+			$('#w4pl_list_options select[name="w4pl[starter_template]"]').val('');
+
 			var message = (window.w4plListEditor && window.w4plListEditor.refreshFailed) ?
 				window.w4plListEditor.refreshFailed :
 				'Could not refresh the form. Your entries are unchanged - check your connection and try again.';

--- a/includes/class-starter-templates.php
+++ b/includes/class-starter-templates.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * Starter template registry and copy-on-select application.
+ *
+ * Starters are ready-made template/CSS/option bundles a user picks in the
+ * list editor. Unlike the legacy preset system (W4PL_Helper_Presets, kept
+ * untouched for lists that already store a `preset` key), applying a
+ * starter COPIES its content into the visible, editable Template and Style
+ * fields — one-shot, in the editor only, never at render time, and the
+ * selection itself is never persisted.
+ *
+ * Third parties can add starters via the `w4pl/starter_templates` filter.
+ *
+ * @class W4PL_Starter_Templates
+ * @package W4_Post_List
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Starter template registry.
+ */
+class W4PL_Starter_Templates {
+
+	/**
+	 * Constructor
+	 */
+	public function __construct() {
+		// Closes the pick-then-publish race: a starter still pending in the
+		// posted options (form refresh not completed) is applied on save.
+		// Also guarantees the one-shot key itself is never persisted.
+		add_filter( 'w4pl/pre_save_options', array( $this, 'apply_on_save' ), 5 );
+	}
+
+	/**
+	 * Apply any pending starter during save.
+	 *
+	 * @param  array $options Options about to be persisted.
+	 * @return array
+	 */
+	public function apply_on_save( $options ) {
+		return self::apply( $options );
+	}
+
+	/**
+	 * Option keys a starter is allowed to set when applied.
+	 *
+	 * @var array
+	 */
+	private static $allowed_option_keys = array(
+		'groupby',
+		'posts_per_page',
+		'orderby',
+		'order',
+		'terms_taxonomy',
+		'users_orderby',
+		'users_order',
+	);
+
+	/**
+	 * All registered starters.
+	 *
+	 * @return array id => { label, description, list_type, template, css, options }
+	 */
+	public static function get_registry() {
+		return apply_filters( 'w4pl/starter_templates', self::core_starters() );
+	}
+
+	/**
+	 * One starter by id.
+	 *
+	 * @param  string $id Starter id.
+	 * @return array|null
+	 */
+	public static function get( $id ) {
+		$registry = self::get_registry();
+
+		if ( isset( $registry[ $id ] ) ) {
+			return $registry[ $id ];
+		}
+
+		return null;
+	}
+
+	/**
+	 * Select-field choices for a list type.
+	 *
+	 * @param  string $list_type Current list type.
+	 * @return array
+	 */
+	public static function options_for_select( $list_type ) {
+		$choices = array(
+			'' => __( '&mdash; Start from a template &mdash;', 'w4-post-list' ),
+		);
+
+		foreach ( self::get_registry() as $id => $starter ) {
+			if ( $starter['list_type'] === $list_type ) {
+				$choices[ $id ] = $starter['label'];
+			}
+		}
+
+		return $choices;
+	}
+
+	/**
+	 * Apply a picked starter to editor options (copy-on-select).
+	 *
+	 * Populates template/css and the starter's related query options, then
+	 * clears the selection so it is a one-shot action. Intentionally
+	 * overwrites existing template/css (maintainer decision).
+	 *
+	 * @param  array $options Editor options, possibly holding starter_template.
+	 * @return array
+	 */
+	public static function apply( $options ) {
+		if ( ! is_array( $options ) || ! isset( $options['starter_template'] ) ) {
+			return $options;
+		}
+
+		$starter_id = $options['starter_template'];
+
+		// Always consume the one-shot key, picked or not.
+		unset( $options['starter_template'] );
+
+		if ( empty( $starter_id ) ) {
+			return $options;
+		}
+
+		$starter = self::get( $starter_id );
+
+		if ( ! $starter ) {
+			return $options;
+		}
+
+		if ( isset( $options['list_type'] ) && $options['list_type'] !== $starter['list_type'] ) {
+			return $options;
+		}
+
+		$options['template'] = $starter['template'];
+		$options['css']      = $starter['css'];
+
+		if ( ! empty( $starter['options'] ) && is_array( $starter['options'] ) ) {
+			foreach ( $starter['options'] as $key => $value ) {
+				if ( in_array( $key, self::$allowed_option_keys, true ) ) {
+					$options[ $key ] = $value;
+				}
+			}
+		}
+
+		return $options;
+	}
+
+	/**
+	 * Built-in starter library.
+	 *
+	 * @return array
+	 */
+	private static function core_starters() {
+		$starters = array();
+
+		// Registry entries are integrated from data/starter-templates.php to
+		// keep the long template/css strings out of class logic.
+		$data_file = W4PL_DIR . '/includes/data/starter-templates.php';
+		if ( file_exists( $data_file ) ) {
+			$starters = include $data_file;
+		}
+
+		if ( ! is_array( $starters ) ) {
+			$starters = array();
+		}
+
+		return $starters;
+	}
+}

--- a/includes/class-starter-templates.php
+++ b/includes/class-starter-templates.php
@@ -52,20 +52,61 @@ class W4PL_Starter_Templates {
 	private static $allowed_option_keys = array(
 		'groupby',
 		'posts_per_page',
+		'limit',
 		'orderby',
 		'order',
 		'terms_taxonomy',
+		'terms_orderby',
+		'terms_order',
 		'users_orderby',
 		'users_order',
 	);
 
 	/**
-	 * All registered starters.
+	 * All registered starters, shape-normalized.
 	 *
-	 * @return array id => { label, description, list_type, template, css, options }
+	 * Filter entries are parsed against a default shape; entries without a
+	 * usable list_type or template are dropped so a malformed third-party
+	 * starter can never emit warnings or write null into list options.
+	 *
+	 * @return array id => { label, description, list_type, template, css, options, thumbnail }
 	 */
 	public static function get_registry() {
-		return apply_filters( 'w4pl/starter_templates', self::core_starters() );
+		$raw = apply_filters( 'w4pl/starter_templates', self::core_starters() );
+
+		$registry = array();
+		$defaults = array(
+			'label'       => '',
+			'description' => '',
+			'list_type'   => '',
+			'template'    => '',
+			'css'         => '',
+			'options'     => array(),
+			'thumbnail'   => '',
+		);
+
+		foreach ( (array) $raw as $id => $starter ) {
+			if ( ! is_array( $starter ) ) {
+				continue;
+			}
+
+			$starter = wp_parse_args( $starter, $defaults );
+
+			if ( ! is_string( $starter['list_type'] ) || '' === $starter['list_type'] || ! is_string( $starter['template'] ) || '' === $starter['template'] ) {
+				continue;
+			}
+
+			if ( ! is_string( $starter['css'] ) ) {
+				$starter['css'] = '';
+			}
+			if ( ! is_array( $starter['options'] ) ) {
+				$starter['options'] = array();
+			}
+
+			$registry[ $id ] = $starter;
+		}
+
+		return $registry;
 	}
 
 	/**
@@ -124,7 +165,9 @@ class W4PL_Starter_Templates {
 		// Always consume the one-shot key, picked or not.
 		unset( $options['starter_template'] );
 
-		if ( empty( $starter_id ) ) {
+		// Only a plain non-empty string can name a starter; anything else
+		// (crafted array input, empty selection) is a no-op.
+		if ( ! is_string( $starter_id ) || '' === $starter_id ) {
 			return $options;
 		}
 
@@ -147,6 +190,10 @@ class W4PL_Starter_Templates {
 					$options[ $key ] = $value;
 				}
 			}
+		}
+
+		if ( class_exists( 'W4PL_Stats' ) ) {
+			W4PL_Stats::increment( 'starter_applied' );
 		}
 
 		return $options;

--- a/includes/class-w4-post-list.php
+++ b/includes/class-w4-post-list.php
@@ -87,6 +87,7 @@ final class W4_Post_List {
 		include W4PL_DIR . '/includes/class-post-types.php';
 		include W4PL_DIR . '/includes/class-options-migrator.php';
 		include W4PL_DIR . '/includes/class-stats.php';
+		include W4PL_DIR . '/includes/class-starter-templates.php';
 		include W4PL_DIR . '/includes/class-list-templates.php';
 		include W4PL_DIR . '/includes/class-list-helper.php';
 		include W4PL_DIR . '/includes/class-list-content.php';
@@ -151,6 +152,7 @@ final class W4_Post_List {
 
 		new W4PL_Options_Migrator();
 		new W4PL_Stats();
+		new W4PL_Starter_Templates();
 		new W4PL_List_Helper();
 		new W4PL_Helper_Posts();
 		new W4PL_Helper_Terms();

--- a/includes/class-w4-post-list.php
+++ b/includes/class-w4-post-list.php
@@ -29,7 +29,7 @@ final class W4_Post_List {
 	 *
 	 * @var string
 	 */
-	public $version = '2.8.0';
+	public $version = '2.9.0';
 
 	/**
 	 * This will hold current class instance

--- a/includes/data/starter-templates.php
+++ b/includes/data/starter-templates.php
@@ -1,0 +1,407 @@
+<?php
+/**
+ * Built-in starter template library. Returned by W4PL_Starter_Templates.
+ *
+ * Generated content; strings use real tabs/newlines. Labels/descriptions
+ * are translated at registry load.
+ *
+ * @package W4_Post_List
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+return array(
+	'simple-list' => array(
+		'label'       => __( 'Simple list', 'w4-post-list' ),
+		'description' => __( 'A plain bulleted list of post titles you can click, with page navigation at the bottom.', 'w4-post-list' ),
+		'list_type'   => 'posts',
+		'template'    => '<div class="w4pl-simple-list">
+	<ul class="simple-list-items">
+		[posts]
+		<li class="post-item">
+			<a class="post-title" href="[post_permalink]">[post_title]</a>
+		</li>
+		[/posts]
+	</ul>
+	[nav]
+</div>',
+		'css'         => '#w4pl-list-[listid] .simple-list-items {
+	margin: 0;
+	padding-left: 1.25em;
+}
+#w4pl-list-[listid] .post-item {
+	margin-bottom: 0.5em;
+}',
+		'options'     => array(
+			'posts_per_page' => 10,
+			'orderby' => 'date',
+			'order' => 'DESC',
+		),
+	),
+	'thumbnail-cards' => array(
+		'label'       => __( 'Thumbnail cards', 'w4-post-list' ),
+		'description' => __( 'A grid of cards showing each post\'s picture, title, and a short preview, with three cards per row on desktop and one per row on phones.', 'w4-post-list' ),
+		'list_type'   => 'posts',
+		'template'    => '<div class="w4pl-cards">
+	[posts]
+	<div class="post-item">
+		<a class="post-thumb" href="[post_permalink]">
+			[featured_image size="medium"]
+		</a>
+		<h3 class="post-title">
+			<a href="[post_permalink]">[post_title]</a>
+		</h3>
+		<div class="post-excerpt">
+			[post_excerpt wordlimit="15"]
+		</div>
+	</div>
+	[/posts]
+</div>
+[nav]',
+		'css'         => '#w4pl-list-[listid] .w4pl-cards {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+	gap: 1.5em;
+}
+#w4pl-list-[listid] .post-item {
+	display: flex;
+	flex-direction: column;
+	border: 1px solid #e5e5e5;
+	border-radius: 6px;
+	overflow: hidden;
+}
+#w4pl-list-[listid] .post-thumb {
+	display: block;
+	line-height: 0;
+}
+#w4pl-list-[listid] .post-thumb img {
+	width: 100%;
+	height: auto;
+}
+#w4pl-list-[listid] .post-title {
+	margin: 0.75em 1em 0.25em;
+	font-size: 1.1em;
+}
+#w4pl-list-[listid] .post-title a {
+	text-decoration: none;
+}
+#w4pl-list-[listid] .post-excerpt {
+	margin: 0 1em 1em;
+	font-size: 0.9em;
+	color: #666;
+}',
+		'options'     => array(
+			'posts_per_page' => 9,
+		),
+	),
+	'title-date-list' => array(
+		'label'       => __( 'Title & date list', 'w4-post-list' ),
+		'description' => __( 'A clean archive-style list where each post title sits on the left and its publish date on the right, separated by thin divider lines.', 'w4-post-list' ),
+		'list_type'   => 'posts',
+		'template'    => '<div class="w4pl-title-date-list">
+	[posts]
+	<div class="post-item">
+		<a class="post-title" href="[post_permalink]">[post_title]</a>
+		<span class="post-date">[post_date format="M j, Y"]</span>
+	</div>
+	[/posts]
+	[nav]
+</div>',
+		'css'         => '#w4pl-list-[listid] .w4pl-title-date-list .post-item {
+	display: flex;
+	align-items: baseline;
+	justify-content: space-between;
+	gap: 1em;
+	padding: 0.6em 0;
+	border-bottom: 1px solid #e5e5e5;
+}
+#w4pl-list-[listid] .w4pl-title-date-list .post-item:last-of-type {
+	border-bottom: none;
+}
+#w4pl-list-[listid] .w4pl-title-date-list .post-title {
+	text-decoration: none;
+}
+#w4pl-list-[listid] .w4pl-title-date-list .post-title:hover {
+	text-decoration: underline;
+}
+#w4pl-list-[listid] .w4pl-title-date-list .post-date {
+	white-space: nowrap;
+	color: #777;
+	font-size: 0.875em;
+}',
+		'options'     => array(
+			'posts_per_page' => 10,
+			'orderby' => 'date',
+			'order' => 'DESC',
+		),
+	),
+	'year-archive' => array(
+		'label'       => __( 'Year archive', 'w4-post-list' ),
+		'description' => __( 'A classic blog archive that groups your posts under big year headings, with each year showing a simple list of clickable post titles and dates.', 'w4-post-list' ),
+		'list_type'   => 'posts',
+		'template'    => '<div class="w4pl-year-archive">
+	[groups]
+	<section class="group-item">
+		<h3 class="group-title">[group_title]</h3>
+		<ul class="archive-posts">
+			[posts]
+			<li class="post-item">
+				<a class="post-title" href="[post_permalink]">[post_title]</a>
+				<span class="post-date">[post_date format="F j"]</span>
+			</li>
+			[/posts]
+		</ul>
+	</section>
+	[/groups]
+	[nav]
+</div>',
+		'css'         => '#w4pl-list-[listid] .w4pl-year-archive {
+	display: flex;
+	flex-direction: column;
+	gap: 2em;
+}
+#w4pl-list-[listid] .group-title {
+	margin: 0 0 0.5em;
+	padding-bottom: 0.3em;
+	border-bottom: 1px solid #e0e0e0;
+}
+#w4pl-list-[listid] .archive-posts {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 0.5em;
+}
+#w4pl-list-[listid] .post-item {
+	display: flex;
+	justify-content: space-between;
+	align-items: baseline;
+	gap: 1em;
+}
+#w4pl-list-[listid] .post-date {
+	color: #888;
+	font-size: 0.875em;
+	white-space: nowrap;
+}',
+		'options'     => array(
+			'groupby' => 'year',
+			'orderby' => 'date',
+			'order' => 'DESC',
+			'posts_per_page' => 20,
+		),
+	),
+	'category-index' => array(
+		'label'       => __( 'Category index', 'w4-post-list' ),
+		'description' => __( 'A neat multi-column index of your categories, each shown as a clickable name with a small badge indicating how many posts it contains.', 'w4-post-list' ),
+		'list_type'   => 'terms',
+		'template'    => '<ul class="w4pl-category-index">
+	[terms]
+	<li class="term-item">
+		<a class="term-name" href="[term_link]">[term_name]</a>
+		<span class="term-count">[term_count]</span>
+	</li>
+	[/terms]
+</ul>',
+		'css'         => '#w4pl-list-[listid] .w4pl-category-index {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+	gap: 0.5em 1.5em;
+}
+#w4pl-list-[listid] .term-item {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 0.5em;
+	padding: 0.35em 0;
+	border-bottom: 1px solid #eee;
+}
+#w4pl-list-[listid] .term-name {
+	text-decoration: none;
+}
+#w4pl-list-[listid] .term-name:hover {
+	text-decoration: underline;
+}
+#w4pl-list-[listid] .term-count {
+	font-size: 0.8em;
+	background: #f2f2f2;
+	color: #666;
+	border-radius: 999px;
+	padding: 0.1em 0.6em;
+}',
+		'options'     => array(
+			'terms_taxonomy' => 'category',
+		),
+	),
+	'category-posts-index' => array(
+		'label'       => __( 'Category index with posts', 'w4-post-list' ),
+		'description' => __( 'An organized index where each category appears as a bold heading with its posts listed underneath as clickable links.', 'w4-post-list' ),
+		'list_type'   => 'terms.posts',
+		'template'    => '<div class="w4pl-category-index">
+	[terms]
+	<section class="term-item">
+		<h3 class="term-name">
+			<a href="[term_link]">[term_name]</a>
+		</h3>
+		<ul class="term-posts">
+			[posts]
+			<li class="post-item">
+				<a class="post-title" href="[post_permalink]">[post_title]</a>
+			</li>
+			[/posts]
+		</ul>
+	</section>
+	[/terms]
+</div>',
+		'css'         => '#w4pl-list-[listid] .w4pl-category-index {
+	display: flex;
+	flex-direction: column;
+	gap: 1.5em;
+}
+#w4pl-list-[listid] .term-item {
+	padding-bottom: 1em;
+	border-bottom: 1px solid #e5e5e5;
+}
+#w4pl-list-[listid] .term-name {
+	margin: 0 0 0.5em;
+}
+#w4pl-list-[listid] .term-name a {
+	text-decoration: none;
+}
+#w4pl-list-[listid] .term-posts {
+	margin: 0;
+	padding-left: 1.25em;
+}
+#w4pl-list-[listid] .post-item {
+	margin: 0.25em 0;
+}',
+		'options'     => array(
+			'terms_taxonomy' => 'category',
+			'orderby' => 'title',
+			'order' => 'ASC',
+		),
+	),
+	'user-directory' => array(
+		'label'       => __( 'User directory cards', 'w4-post-list' ),
+		'description' => __( 'A member directory shown as a grid of centered cards, each with the person\'s photo, their name linked to their posts, and a short bio.', 'w4-post-list' ),
+		'list_type'   => 'users',
+		'template'    => '<div class="w4pl-user-directory">
+	[users]
+	<div class="user-item">
+		<div class="user-avatar">[user_avatar]</div>
+		<h3 class="user-name">
+			<a href="[user_link]">[user_name]</a>
+		</h3>
+		<p class="user-bio">[user_bio]</p>
+	</div>
+	[/users]
+</div>',
+		'css'         => '#w4pl-list-[listid] .w4pl-user-directory {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+	gap: 1.25em;
+}
+#w4pl-list-[listid] .user-item {
+	text-align: center;
+	padding: 1.5em 1em;
+	border: 1px solid #e5e5e5;
+	border-radius: 8px;
+}
+#w4pl-list-[listid] .user-avatar img {
+	border-radius: 50%;
+	max-width: 100%;
+	height: auto;
+}
+#w4pl-list-[listid] .user-name {
+	margin: 0.75em 0 0.25em;
+}
+#w4pl-list-[listid] .user-name a {
+	text-decoration: none;
+}
+#w4pl-list-[listid] .user-bio {
+	margin: 0;
+	font-size: 0.9em;
+	color: #666;
+}',
+		'options'     => array(
+			'users_orderby' => 'display_name',
+			'users_order' => 'ASC',
+		),
+	),
+	'authors-posts' => array(
+		'label'       => __( 'Author sections', 'w4-post-list' ),
+		'description' => __( 'Each author appears as a heading row with their photo and name, followed by a short list of their latest posts you can click to read.', 'w4-post-list' ),
+		'list_type'   => 'users.posts',
+		'template'    => '<div class="w4pl-author-sections">
+	[users]
+	<section class="user-item">
+		<div class="author-heading">
+			<span class="user-avatar">[user_avatar]</span>
+			<h3 class="user-name">
+				<a href="[user_link]">[user_name]</a>
+			</h3>
+		</div>
+		<ul class="author-posts">
+			[posts]
+			<li class="post-item">
+				<a class="post-title" href="[post_permalink]">[post_title]</a>
+				<span class="post-date">[post_date format="M j, Y"]</span>
+			</li>
+			[/posts]
+		</ul>
+	</section>
+	[/users]
+</div>',
+		'css'         => '#w4pl-list-[listid] .w4pl-author-sections {
+	display: flex;
+	flex-direction: column;
+	gap: 2em;
+}
+#w4pl-list-[listid] .author-heading {
+	display: flex;
+	align-items: center;
+	gap: 0.75em;
+	padding-bottom: 0.5em;
+	border-bottom: 1px solid #e5e5e5;
+}
+#w4pl-list-[listid] .user-avatar img {
+	border-radius: 50%;
+	width: 48px;
+	height: 48px;
+}
+#w4pl-list-[listid] .user-name {
+	margin: 0;
+}
+#w4pl-list-[listid] .author-posts {
+	list-style: none;
+	margin: 0.75em 0 0;
+	padding: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 0.5em;
+}
+#w4pl-list-[listid] .post-item {
+	display: flex;
+	align-items: baseline;
+	justify-content: space-between;
+	gap: 1em;
+}
+#w4pl-list-[listid] .post-date {
+	color: #888;
+	font-size: 0.875em;
+	white-space: nowrap;
+}',
+		'options'     => array(
+			'posts_per_page' => 5,
+			'orderby' => 'date',
+			'order' => 'DESC',
+			'users_orderby' => 'display_name',
+			'users_order' => 'ASC',
+		),
+	),
+);

--- a/includes/data/starter-templates.php
+++ b/includes/data/starter-templates.php
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 return array(
-	'simple-list' => array(
+	'simple-list'          => array(
 		'label'       => __( 'Simple list', 'w4-post-list' ),
 		'description' => __( 'A plain bulleted list of post titles you can click, with page navigation at the bottom.', 'w4-post-list' ),
 		'list_type'   => 'posts',
@@ -34,15 +34,16 @@ return array(
 #w4pl-list-[listid] .post-item {
 	margin-bottom: 0.5em;
 }',
+		'thumbnail'   => '',
 		'options'     => array(
 			'posts_per_page' => 10,
-			'orderby' => 'date',
-			'order' => 'DESC',
+			'orderby'        => 'date',
+			'order'          => 'DESC',
 		),
 	),
-	'thumbnail-cards' => array(
+	'thumbnail-cards'      => array(
 		'label'       => __( 'Thumbnail cards', 'w4-post-list' ),
-		'description' => __( 'A grid of cards showing each post\'s picture, title, and a short preview, with three cards per row on desktop and one per row on phones.', 'w4-post-list' ),
+		'description' => __( 'A grid of cards showing each post\'s picture, title, and a short preview, the grid adapts to the available width, one card per row on phones.', 'w4-post-list' ),
 		'list_type'   => 'posts',
 		'template'    => '<div class="w4pl-cards">
 	[posts]
@@ -92,11 +93,12 @@ return array(
 	font-size: 0.9em;
 	color: #666;
 }',
+		'thumbnail'   => '',
 		'options'     => array(
 			'posts_per_page' => 9,
 		),
 	),
-	'title-date-list' => array(
+	'title-date-list'      => array(
 		'label'       => __( 'Title & date list', 'w4-post-list' ),
 		'description' => __( 'A clean archive-style list where each post title sits on the left and its publish date on the right, separated by thin divider lines.', 'w4-post-list' ),
 		'list_type'   => 'posts',
@@ -107,8 +109,8 @@ return array(
 		<span class="post-date">[post_date format="M j, Y"]</span>
 	</div>
 	[/posts]
-	[nav]
-</div>',
+</div>
+[nav]',
 		'css'         => '#w4pl-list-[listid] .w4pl-title-date-list .post-item {
 	display: flex;
 	align-items: baseline;
@@ -131,13 +133,14 @@ return array(
 	color: #777;
 	font-size: 0.875em;
 }',
+		'thumbnail'   => '',
 		'options'     => array(
 			'posts_per_page' => 10,
-			'orderby' => 'date',
-			'order' => 'DESC',
+			'orderby'        => 'date',
+			'order'          => 'DESC',
 		),
 	),
-	'year-archive' => array(
+	'year-archive'         => array(
 		'label'       => __( 'Year archive', 'w4-post-list' ),
 		'description' => __( 'A classic blog archive that groups your posts under big year headings, with each year showing a simple list of clickable post titles and dates.', 'w4-post-list' ),
 		'list_type'   => 'posts',
@@ -186,14 +189,15 @@ return array(
 	font-size: 0.875em;
 	white-space: nowrap;
 }',
+		'thumbnail'   => '',
 		'options'     => array(
-			'groupby' => 'year',
-			'orderby' => 'date',
-			'order' => 'DESC',
+			'groupby'        => 'year',
+			'orderby'        => 'date',
+			'order'          => 'DESC',
 			'posts_per_page' => 20,
 		),
 	),
-	'category-index' => array(
+	'category-index'       => array(
 		'label'       => __( 'Category index', 'w4-post-list' ),
 		'description' => __( 'A neat multi-column index of your categories, each shown as a clickable name with a small badge indicating how many posts it contains.', 'w4-post-list' ),
 		'list_type'   => 'terms',
@@ -234,8 +238,11 @@ return array(
 	border-radius: 999px;
 	padding: 0.1em 0.6em;
 }',
+		'thumbnail'   => '',
 		'options'     => array(
 			'terms_taxonomy' => 'category',
+			'terms_orderby'  => 'name',
+			'terms_order'    => 'ASC',
 		),
 	),
 	'category-posts-index' => array(
@@ -280,13 +287,17 @@ return array(
 #w4pl-list-[listid] .post-item {
 	margin: 0.25em 0;
 }',
+		'thumbnail'   => '',
 		'options'     => array(
 			'terms_taxonomy' => 'category',
-			'orderby' => 'title',
-			'order' => 'ASC',
+			'terms_orderby'  => 'name',
+			'terms_order'    => 'ASC',
+			'limit'          => 5,
+			'orderby'        => 'title',
+			'order'          => 'ASC',
 		),
 	),
-	'user-directory' => array(
+	'user-directory'       => array(
 		'label'       => __( 'User directory cards', 'w4-post-list' ),
 		'description' => __( 'A member directory shown as a grid of centered cards, each with the person\'s photo, their name linked to their posts, and a short bio.', 'w4-post-list' ),
 		'list_type'   => 'users',
@@ -328,12 +339,13 @@ return array(
 	font-size: 0.9em;
 	color: #666;
 }',
+		'thumbnail'   => '',
 		'options'     => array(
 			'users_orderby' => 'display_name',
-			'users_order' => 'ASC',
+			'users_order'   => 'ASC',
 		),
 	),
-	'authors-posts' => array(
+	'authors-posts'        => array(
 		'label'       => __( 'Author sections', 'w4-post-list' ),
 		'description' => __( 'Each author appears as a heading row with their photo and name, followed by a short list of their latest posts you can click to read.', 'w4-post-list' ),
 		'list_type'   => 'users.posts',
@@ -396,12 +408,13 @@ return array(
 	font-size: 0.875em;
 	white-space: nowrap;
 }',
+		'thumbnail'   => '',
 		'options'     => array(
-			'posts_per_page' => 5,
-			'orderby' => 'date',
-			'order' => 'DESC',
+			'limit'         => 5,
+			'orderby'       => 'date',
+			'order'         => 'DESC',
 			'users_orderby' => 'display_name',
-			'users_order' => 'ASC',
+			'users_order'   => 'ASC',
 		),
 	),
 );

--- a/includes/functions-form.php
+++ b/includes/functions-form.php
@@ -300,7 +300,7 @@ function w4pl_form_field_html( $args = array() ) {
 						$l     = $l['label'];
 					}
 
-					$html .= sprintf( '<option value="%1$s"%2$s%4$s>%3$s</option>', $k, $sel, $l, $_attr );
+					$html .= sprintf( '<option value="%1$s"%2$s%4$s>%3$s</option>', esc_attr( $k ), $sel, $l, $_attr );
 				}
 				$html .= '</select>';
 

--- a/includes/functions-form.php
+++ b/includes/functions-form.php
@@ -43,7 +43,9 @@ function w4pl_form_fields( $fields = array(), $values = array(), $form_args = ar
 
 	if ( empty( $form_args['action'] ) ) {
 		$schema              = is_ssl() ? 'https://' : 'http://';
-		$form_args['action'] = $schema . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+		$host                = isset( $_SERVER['HTTP_HOST'] ) ? $_SERVER['HTTP_HOST'] : '';
+		$uri                 = isset( $_SERVER['REQUEST_URI'] ) ? $_SERVER['REQUEST_URI'] : '';
+		$form_args['action'] = $schema . $host . $uri;
 	}
 
 	if ( ! empty( $form_args['qv'] ) ) {

--- a/includes/helpers/class-helper-presets.php
+++ b/includes/helpers/class-helper-presets.php
@@ -34,18 +34,21 @@ class W4PL_Helper_Presets {
 	 * @return array          List editor fields.
 	 */
 	public function list_edit_form_fields( $fields, $options ) {
-		$fields['preset'] = array(
-			'position'    => '3.1',
-			'option_name' => 'preset',
-			'name'        => 'w4pl[preset]',
-			'label'       => __( 'Preset', 'w4-post-list' ),
-			'type'        => 'select',
-			'option'      => self::preset_options( $options['list_type'] ),
-			'input_class' => 'w4pl_onchange_lfr',
-			'desc'        => __( 'Presets are ready-made templates. When one is selected it controls the output, and the Template and Style sections are hidden.', 'w4-post-list' ),
-		);
-
+		// Lists that store a legacy preset keep the old field and its
+		// render-time override untouched. Everything else gets the modern
+		// copy-on-select starter picker.
 		if ( isset( $options['preset'] ) && ! empty( $options['preset'] ) ) {
+			$fields['preset'] = array(
+				'position'    => '3.1',
+				'option_name' => 'preset',
+				'name'        => 'w4pl[preset]',
+				'label'       => __( 'Preset (legacy)', 'w4-post-list' ),
+				'type'        => 'select',
+				'option'      => self::preset_options( $options['list_type'] ),
+				'input_class' => 'w4pl_onchange_lfr',
+				'desc'        => __( 'This list uses a legacy preset that controls its output; the Template and Style sections are hidden. Select "Custom" to take manual control.', 'w4-post-list' ),
+			);
+
 			unset(
 				$fields['before_field_group_style'],
 				$fields['js'],
@@ -56,7 +59,20 @@ class W4PL_Helper_Presets {
 				$fields['template1'],
 				$fields['after_field_group_template']
 			);
+
+			return $fields;
 		}
+
+		$fields['starter_template'] = array(
+			'position'    => '3.1',
+			'option_name' => 'starter_template',
+			'name'        => 'w4pl[starter_template]',
+			'label'       => __( 'Start from a template', 'w4-post-list' ),
+			'type'        => 'select',
+			'option'      => W4PL_Starter_Templates::options_for_select( $options['list_type'] ),
+			'input_class' => 'w4pl_onchange_lfr',
+			'desc'        => __( 'Copies a ready-made layout into the Template and Style sections below, replacing their current content — then edit freely. Some templates also set related options (like Group by).', 'w4-post-list' ),
+		);
 
 		return $fields;
 	}
@@ -70,6 +86,9 @@ class W4PL_Helper_Presets {
 		if ( ! isset( $options ) || ! is_array( $options ) ) {
 			$options = array();
 		}
+
+		// The starter picker is a one-shot editor action, never stored.
+		unset( $options['starter_template'] );
 
 		// Quick kill.
 		if ( empty( $options['preset'] ) ) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "w4-post-list",
-	"version": "2.8.0",
+	"version": "2.9.0",
 	"description": "A WordPress Plugin for listing posts in some handy manner.",
 	"main": "Gruntfile.js",
 	"scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: post list, user list, post grid, category list, shortcode
 Requires at least: 5.8
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 2.8.0
+Stable tag: 2.9.0
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -58,7 +58,7 @@ Place any list anywhere with the **W4 Post List block**, the `[postlist id="123"
 
 = Full control over the output =
 
-Output is template-driven: every list has an HTML template with template tags like `[post_title]`, `[post_permalink]`, `[featured_image]`, `[post_author_name]` and `[post_meta key="..."]`. Start from a preset and tweak it, or write your own markup for pixel-perfect control. If you want a drag-and-drop visual builder, this plugin isn't that — it keeps you close to your own HTML, which is exactly why themes and developers like it.
+Output is template-driven: every list has an HTML template with template tags like `[post_title]`, `[post_permalink]`, `[featured_image]`, `[post_author_name]` and `[post_meta key="..."]`. Start from a ready-made template — cards, archives, category indexes, user directories — and tweak it, or write your own markup for pixel-perfect control. If you want a drag-and-drop visual builder, this plugin isn't that — it keeps you close to your own HTML, which is exactly why themes and developers like it.
 
 See the [full template tag reference](https://w4dev.com/docs/w4-post-list/faqs/what-are-the-available-template-tags/) and [live examples with copy-paste templates](https://w4dev.com/wp/w4-post-list-examples/).
 
@@ -88,6 +88,10 @@ Create a Posts list, open the **Posts: Tax Query** section, and select your taxo
 
 The usual causes, in order: the list is not **Published** yet; the shortcode ID doesn't match (check the Shortcode column on the All Lists screen); the template is missing its loop tags (a Posts list template needs `[posts]...[/posts]`, Terms needs `[terms]...[/terms]`, Users needs `[users]...[/users]`); or the query simply matched no items. Opening the list and re-checking the query options usually finds it.
 
+= Do I have to write the template myself? =
+
+No. Pick a layout from **Start from a template** in the list editor — thumbnail cards, a year archive, a category index, a user directory and more. It copies the markup and styles into the editable Template and Style fields, so you can use it as-is or adjust anything.
+
 = Can I display custom fields (including ACF)? =
 
 Yes. Use `[post_meta key="your_field_key"]` inside the posts loop. Fields stored as plain values (text, numbers, URLs) work best; complex/serialized fields are output as stored.
@@ -116,6 +120,12 @@ In your admin: **W4 Post List → Documentation** (template tags reference, exam
 
 
 == Changelog ==
+= 2.9.0 =
+* New: "Start from a template" - pick from 8 ready-made layouts (simple list, thumbnail cards, title & date list, year archive, category index, category index with posts, user directory, authors with posts). Picking one copies editable markup and styles into the Template and Style fields and sets the options it needs, like Group by. Developers can add layouts via the w4pl/starter_templates filter.
+* Improved: Lists using a legacy preset keep working exactly as before; the legacy preset field only appears on those lists.
+* Improved: In-plugin docs updated for the new flow; new FAQ "Do I have to write the template myself?".
+* Fix: Guarded the editor form action URL against missing server variables (CLI contexts).
+* Dev: Select field values are now attribute-escaped in the form engine.
 = 2.8.0 =
 * New: The Template, CSS and JavaScript fields are now real code editors with syntax highlighting and line numbers; template tags insert at the cursor.
 * Improved: Default templates rewritten in the plain tag dialect with a visible per-item wrapper (div.post-item / .term-item / .user-item) and the [nav] pagination tag, so the loop structure is obvious at a glance. Applies to newly created lists; saved lists keep their stored template.
@@ -166,6 +176,8 @@ In your admin: **W4 Post List → Documentation** (template tags reference, exam
 [See changelog of all versions](https://raw.githubusercontent.com/w4devInc/w4-post-list/master/CHANGELOG.txt).
 
 == Upgrade Notice ==
+= 2.9.0 =
+Eight ready-made starter templates with copy-on-select editing. Legacy presets unchanged.
 = 2.8.0 =
 Code editors for templates, copyable shortcode box, visible error notices for editors, editor stability fixes.
 = 2.7.0 =

--- a/tests/DocsTagsTest.php
+++ b/tests/DocsTagsTest.php
@@ -56,6 +56,12 @@ class DocsTagsTest extends WP_UnitTestCase {
 		}
 	}
 
+	public function test_starter_template_registry_uses_only_registered_tags() {
+		foreach ( W4PL_Starter_Templates::get_registry() as $id => $starter ) {
+			$this->assertTagsRegistered( $this->extract_tags( $starter['template'] ), "starter template $id" );
+		}
+	}
+
 	public function test_preset_templates_use_only_registered_tags() {
 		$presets = new W4PL_Helper_Presets();
 		$combos  = array(

--- a/tests/ListRenderingTest.php
+++ b/tests/ListRenderingTest.php
@@ -2,137 +2,15 @@
 /**
  * Characterization tests for the options -> HTML rendering contract.
  *
- * These snapshots freeze the output of the rendering pipeline for all five
- * list types. They are the compatibility guarantee for lists stored on
- * existing sites: a refactor that changes any snapshot is a breaking change
- * until proven otherwise. Regenerate deliberately with:
- *
- *   W4PL_UPDATE_SNAPSHOTS=1 vendor-dev/bin/phpunit --filter ListRenderingTest
+ * Snapshots freeze the rendered output; regenerate deliberately with
+ * W4PL_UPDATE_SNAPSHOTS=1.
  *
  * @package W4_Post_List
  */
 
-class ListRenderingTest extends WP_UnitTestCase {
+require_once __DIR__ . '/class-w4pl-snapshot-testcase.php';
 
-	protected static $cat_alpha;
-	protected static $cat_beta;
-	protected static $user_ann;
-	protected static $user_bob;
-	protected static $post_ids = array();
-
-	public static function wpSetUpBeforeClass( $factory ) {
-		self::$cat_alpha = $factory->term->create(
-			array(
-				'taxonomy' => 'category',
-				'name'     => 'Alpha',
-				'slug'     => 'alpha',
-			)
-		);
-		self::$cat_beta  = $factory->term->create(
-			array(
-				'taxonomy' => 'category',
-				'name'     => 'Beta',
-				'slug'     => 'beta',
-			)
-		);
-
-		self::$user_ann = $factory->user->create(
-			array(
-				'role'         => 'author',
-				'user_login'   => 'ann',
-				'display_name' => 'Ann Author',
-			)
-		);
-		self::$user_bob = $factory->user->create(
-			array(
-				'role'         => 'author',
-				'user_login'   => 'bob',
-				'display_name' => 'Bob Builder',
-			)
-		);
-
-		$fixtures = array(
-			array( 'Winter release notes', '2026-01-05 09:00:00', self::$cat_alpha, self::$user_ann ),
-			array( 'Spring cleaning tips', '2026-04-10 10:00:00', self::$cat_beta, self::$user_bob ),
-			array( 'Year in review', '2025-09-14 12:00:00', self::$cat_alpha, self::$user_ann ),
-			array( 'Interview with a builder', '2025-06-21 08:30:00', self::$cat_beta, self::$user_bob ),
-			array( 'Ten tips for faster sites', '2024-11-02 15:00:00', self::$cat_alpha, self::$user_ann ),
-			array( 'Hello from the archive', '2024-03-10 11:00:00', self::$cat_beta, self::$user_bob ),
-		);
-
-		foreach ( $fixtures as $f ) {
-			self::$post_ids[] = $factory->post->create(
-				array(
-					'post_title'    => $f[0],
-					'post_date'     => $f[1],
-					'post_category' => array( $f[2] ),
-					'post_author'   => $f[3],
-					'post_content'  => 'Fixture content for ' . $f[0] . '.',
-					'post_excerpt'  => 'Excerpt for ' . $f[0] . '.',
-				)
-			);
-		}
-	}
-
-	/**
-	 * Render a list from an options array through the same path the
-	 * [postlist] shortcode uses: a real w4pl post with _w4pl meta.
-	 */
-	protected function render_list( array $options ) {
-		$list_id = self::factory()->post->create(
-			array(
-				'post_type'   => 'w4pl',
-				'post_title'  => 'Characterization list',
-				'post_status' => 'publish',
-			)
-		);
-		update_post_meta( $list_id, '_w4pl', $options );
-
-		return do_shortcode( '[postlist id="' . $list_id . '"]' );
-	}
-
-	/**
-	 * Strip run-dependent identifiers so snapshots are stable across runs.
-	 */
-	protected function normalize( $html ) {
-		$patterns = array(
-			'/W4PL_List_\d+/'                 => 'W4PL_List_{ID}',
-			'/w4pl-list-\d+/'                 => 'w4pl-list-{ID}',
-			'/w4pl-inner-\d+/'                => 'w4pl-inner-{ID}',
-			'/w4pl-\d+/'                      => 'w4pl-{ID}',
-			'/\?p=\d+/'                       => '?p={ID}',
-			'/\?page_id=\d+/'                 => '?page_id={ID}',
-			'/\?cat=\d+/'                     => '?cat={ID}',
-			'/\?author=\d+/'                  => '?author={ID}',
-			'/page\d+=(\d+)/'                 => 'page{ID}=$1',
-			'/\b(post|tag|category|user|term)[-_]item[-_]\d+/' => '$1-item-{ID}',
-			'/\bpost-\d+\b/'                  => 'post-{ID}',
-			'/\btag-\d+\b/'                   => 'tag-{ID}',
-		);
-
-		$html = preg_replace( array_keys( $patterns ), array_values( $patterns ), $html );
-
-		// Trim per-line trailing whitespace; keep structure otherwise.
-		$html = preg_replace( '/[ \t]+$/m', '', $html );
-
-		return trim( $html ) . "\n";
-	}
-
-	protected function assertMatchesHtmlSnapshot( $name, $html ) {
-		$normalized = $this->normalize( $html );
-		$dir        = __DIR__ . '/snapshots';
-		$file       = $dir . '/' . $name . '.html';
-
-		if ( getenv( 'W4PL_UPDATE_SNAPSHOTS' ) ) {
-			if ( ! is_dir( $dir ) ) {
-				mkdir( $dir, 0777, true );
-			}
-			file_put_contents( $file, $normalized );
-		}
-
-		$this->assertFileExists( $file, "Snapshot '$name' missing. Generate with W4PL_UPDATE_SNAPSHOTS=1." );
-		$this->assertSame( file_get_contents( $file ), $normalized, "Rendered HTML diverged from snapshot '$name'." );
-	}
+class ListRenderingTest extends W4PL_Snapshot_TestCase {
 
 	public function test_posts_list_default_template() {
 		$html = $this->render_list(

--- a/tests/StarterTemplatesTest.php
+++ b/tests/StarterTemplatesTest.php
@@ -29,13 +29,70 @@ class StarterTemplatesTest extends W4PL_Snapshot_TestCase {
 
 	public function test_registry_entries_are_well_formed() {
 		foreach ( W4PL_Starter_Templates::get_registry() as $id => $starter ) {
-			foreach ( array( 'label', 'description', 'list_type', 'template', 'css', 'options' ) as $key ) {
+			foreach ( array( 'label', 'description', 'list_type', 'template', 'css', 'options', 'thumbnail' ) as $key ) {
 				$this->assertArrayHasKey( $key, $starter, "$id missing $key" );
 			}
 			$this->assertNotEmpty( $starter['template'], "$id has empty template" );
 			$this->assertStringNotContainsString( '&lt;', $starter['template'], "$id template is entity-encoded" );
 			$this->assertIsArray( $starter['options'] );
 		}
+	}
+
+	public function test_malformed_filter_entries_are_dropped() {
+		add_filter(
+			'w4pl/starter_templates',
+			function ( $starters ) {
+				$starters['broken-no-template'] = array( 'list_type' => 'posts' );
+				$starters['broken-not-array']   = 'just a string';
+				$starters['minimal-valid']      = array(
+					'list_type' => 'posts',
+					'template'  => '[posts][post_title][/posts]',
+				);
+				return $starters;
+			}
+		);
+
+		$registry = W4PL_Starter_Templates::get_registry();
+
+		$this->assertArrayNotHasKey( 'broken-no-template', $registry );
+		$this->assertArrayNotHasKey( 'broken-not-array', $registry );
+		$this->assertArrayHasKey( 'minimal-valid', $registry );
+		$this->assertSame( '', $registry['minimal-valid']['css'], 'Missing keys normalized to defaults' );
+		$this->assertSame( array(), $registry['minimal-valid']['options'] );
+	}
+
+	public function test_crafted_array_selection_does_not_fatal() {
+		$options = W4PL_Starter_Templates::apply(
+			array(
+				'list_type'        => 'posts',
+				'template'         => '<p>keep me</p>',
+				'starter_template' => array( 'x' ),
+			)
+		);
+
+		$this->assertArrayNotHasKey( 'starter_template', $options );
+		$this->assertSame( '<p>keep me</p>', $options['template'] );
+	}
+
+	public function test_successful_apply_increments_usage_counter() {
+		delete_option( W4PL_Stats::OPTION );
+
+		W4PL_Starter_Templates::apply(
+			array(
+				'list_type'        => 'posts',
+				'starter_template' => 'simple-list',
+			)
+		);
+		$this->assertSame( 1, W4PL_Stats::get( 'starter_applied' ) );
+
+		// Consumed-but-not-applied selections do not count.
+		W4PL_Starter_Templates::apply(
+			array(
+				'list_type'        => 'posts',
+				'starter_template' => 'does-not-exist',
+			)
+		);
+		$this->assertSame( 1, W4PL_Stats::get( 'starter_applied' ) );
 	}
 
 	public function test_registry_templates_use_only_registered_tags() {

--- a/tests/StarterTemplatesTest.php
+++ b/tests/StarterTemplatesTest.php
@@ -1,0 +1,268 @@
+<?php
+/**
+ * Starter template registry, copy-on-select application, and legacy compat.
+ *
+ * @package W4_Post_List
+ */
+
+require_once __DIR__ . '/class-w4pl-snapshot-testcase.php';
+
+class StarterTemplatesTest extends W4PL_Snapshot_TestCase {
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
+		require_once dirname( __DIR__ ) . '/admin/class-admin-list-editor.php';
+	}
+
+	// ----- Registry validity -----
+
+	public function test_registry_has_eight_starters_covering_all_list_types() {
+		$registry = W4PL_Starter_Templates::get_registry();
+
+		$this->assertGreaterThanOrEqual( 8, count( $registry ) );
+
+		$types = wp_list_pluck( $registry, 'list_type' );
+		foreach ( array( 'posts', 'terms', 'users', 'terms.posts', 'users.posts' ) as $type ) {
+			$this->assertContains( $type, $types, "No starter covers list type $type" );
+		}
+	}
+
+	public function test_registry_entries_are_well_formed() {
+		foreach ( W4PL_Starter_Templates::get_registry() as $id => $starter ) {
+			foreach ( array( 'label', 'description', 'list_type', 'template', 'css', 'options' ) as $key ) {
+				$this->assertArrayHasKey( $key, $starter, "$id missing $key" );
+			}
+			$this->assertNotEmpty( $starter['template'], "$id has empty template" );
+			$this->assertStringNotContainsString( '&lt;', $starter['template'], "$id template is entity-encoded" );
+			$this->assertIsArray( $starter['options'] );
+		}
+	}
+
+	public function test_registry_templates_use_only_registered_tags() {
+		$registered   = array_keys( w4pl_get_shortcodes() );
+		$registered[] = 'postlist';
+
+		foreach ( W4PL_Starter_Templates::get_registry() as $id => $starter ) {
+			preg_match_all( '/\[\/?([a-zA-Z_][a-zA-Z0-9_]*)[\s\]]/', $starter['template'], $m );
+			$unknown = array_diff( array_unique( $m[1] ), $registered );
+
+			$this->assertSame( array(), array_values( $unknown ), "Unregistered tags in starter $id: " . implode( ', ', $unknown ) );
+		}
+	}
+
+	public function test_registry_css_rules_are_scoped_to_the_list() {
+		foreach ( W4PL_Starter_Templates::get_registry() as $id => $starter ) {
+			if ( '' === trim( $starter['css'] ) ) {
+				continue;
+			}
+
+			foreach ( explode( "\n", $starter['css'] ) as $line ) {
+				$line = trim( $line );
+				// Selector lines open a block and are not properties/closers/at-rules.
+				if ( '' === $line || '}' === $line || 0 === strpos( $line, '@' ) || false === strpos( $line, '{' ) ) {
+					continue;
+				}
+				$this->assertStringStartsWith( '#w4pl-list-[listid]', $line, "Unscoped CSS selector in $id: $line" );
+			}
+		}
+	}
+
+	public function test_select_options_filter_by_list_type() {
+		$posts_choices = W4PL_Starter_Templates::options_for_select( 'posts' );
+		$terms_choices = W4PL_Starter_Templates::options_for_select( 'terms' );
+
+		$this->assertArrayHasKey( '', $posts_choices, 'Placeholder choice missing' );
+		$this->assertArrayHasKey( 'thumbnail-cards', $posts_choices );
+		$this->assertArrayNotHasKey( 'category-index', $posts_choices );
+		$this->assertArrayHasKey( 'category-index', $terms_choices );
+		$this->assertArrayNotHasKey( 'thumbnail-cards', $terms_choices );
+	}
+
+	// ----- Copy-on-select application -----
+
+	public function test_apply_copies_template_css_and_related_options() {
+		$options = W4PL_Starter_Templates::apply(
+			array(
+				'list_type'        => 'posts',
+				'starter_template' => 'year-archive',
+				'template'         => '<p>existing content</p>',
+			)
+		);
+
+		$this->assertArrayNotHasKey( 'starter_template', $options, 'One-shot key must be consumed' );
+		$this->assertStringContainsString( '[groups]', $options['template'], 'Starter template applied' );
+		$this->assertStringNotContainsString( 'existing content', $options['template'], 'Overwrites silently by design' );
+		$this->assertStringContainsString( '#w4pl-list-[listid]', $options['css'] );
+		$this->assertSame( 'year', $options['groupby'], 'Related option set' );
+	}
+
+	public function test_apply_consumes_empty_and_unknown_selections_without_changes() {
+		$base = array(
+			'list_type'        => 'posts',
+			'template'         => '<p>keep me</p>',
+			'starter_template' => '',
+		);
+
+		$options = W4PL_Starter_Templates::apply( $base );
+		$this->assertArrayNotHasKey( 'starter_template', $options );
+		$this->assertSame( '<p>keep me</p>', $options['template'] );
+
+		$base['starter_template'] = 'does-not-exist';
+		$options                  = W4PL_Starter_Templates::apply( $base );
+		$this->assertArrayNotHasKey( 'starter_template', $options );
+		$this->assertSame( '<p>keep me</p>', $options['template'] );
+	}
+
+	public function test_apply_refuses_list_type_mismatch() {
+		$options = W4PL_Starter_Templates::apply(
+			array(
+				'list_type'        => 'terms',
+				'template'         => '<p>keep me</p>',
+				'starter_template' => 'thumbnail-cards',
+			)
+		);
+
+		$this->assertSame( '<p>keep me</p>', $options['template'] );
+	}
+
+	public function test_apply_ignores_disallowed_option_keys_from_filtered_starters() {
+		add_filter(
+			'w4pl/starter_templates',
+			function ( $starters ) {
+				$starters['evil'] = array(
+					'label'       => 'Evil',
+					'description' => '',
+					'list_type'   => 'posts',
+					'template'    => '[posts][post_title][/posts]',
+					'css'         => '',
+					'options'     => array(
+						'id'             => 999,
+						'posts_per_page' => 5,
+					),
+				);
+				return $starters;
+			}
+		);
+
+		$options = W4PL_Starter_Templates::apply(
+			array(
+				'list_type'        => 'posts',
+				'id'               => 42,
+				'starter_template' => 'evil',
+			)
+		);
+
+		$this->assertSame( 42, $options['id'], 'Disallowed option key must not apply' );
+		$this->assertSame( 5, $options['posts_per_page'], 'Allowed option key applies' );
+	}
+
+	public function test_pending_starter_applies_on_save_and_is_never_persisted() {
+		$options = apply_filters(
+			'w4pl/pre_save_options',
+			array(
+				'list_type'        => 'posts',
+				'starter_template' => 'simple-list',
+			)
+		);
+
+		$this->assertArrayNotHasKey( 'starter_template', $options );
+		$this->assertStringContainsString( 'w4pl-simple-list', $options['template'] );
+		$this->assertSame( W4PL_Options_Migrator::OPTIONS_VERSION, $options['options_version'] );
+	}
+
+	public function test_editor_applies_starter_before_field_rendering() {
+		$editor = new W4PL_List_Editor(
+			array(
+				'id'               => 1,
+				'list_type'        => 'posts',
+				'starter_template' => 'thumbnail-cards',
+			)
+		);
+
+		$this->assertStringContainsString( 'w4pl-cards', $editor->options['template'] );
+		$this->assertSame( 9, $editor->options['posts_per_page'] );
+		$this->assertArrayNotHasKey( 'starter_template', $editor->options );
+	}
+
+	// ----- Editor field behavior -----
+
+	public function test_lists_without_legacy_preset_get_starter_field() {
+		$options = apply_filters( 'w4pl/pre_get_options', array( 'list_type' => 'posts' ) );
+		$fields  = apply_filters(
+			'w4pl/list_edit_form_fields',
+			array( 'before_field_group_template' => array( 'html' => 'x' ) ),
+			$options
+		);
+
+		$this->assertArrayHasKey( 'starter_template', $fields );
+		$this->assertArrayNotHasKey( 'preset', $fields );
+		$this->assertArrayHasKey( 'before_field_group_template', $fields, 'Template group must stay visible' );
+		$this->assertSame( 'Start from a template', $fields['starter_template']['label'] );
+	}
+
+	public function test_lists_with_legacy_preset_keep_old_field_and_hiding() {
+		$options = apply_filters(
+			'w4pl/pre_get_options',
+			array(
+				'list_type' => 'posts',
+				'preset'    => 'simple_list',
+			)
+		);
+		$fields  = apply_filters(
+			'w4pl/list_edit_form_fields',
+			array( 'before_field_group_template' => array( 'html' => 'x' ) ),
+			$options
+		);
+
+		$this->assertArrayHasKey( 'preset', $fields );
+		$this->assertArrayNotHasKey( 'starter_template', $fields );
+		$this->assertArrayNotHasKey( 'before_field_group_template', $fields, 'Legacy preset lists keep hiding the template group' );
+	}
+
+	// ----- Legacy render-time behavior frozen -----
+
+	public function test_legacy_stored_preset_still_renders_via_override() {
+		$html = $this->render_list(
+			array(
+				'list_type'      => 'posts',
+				'post_type'      => array( 'post' ),
+				'posts_per_page' => 10,
+				'orderby'        => 'post_date',
+				'order'          => 'DESC',
+				'preset'         => 'simple_list',
+			)
+		);
+
+		$this->assertMatchesHtmlSnapshot( 'legacy-preset-simple-list', $html );
+	}
+
+	// ----- Every starter renders -----
+
+	public function starter_provider() {
+		$cases = array();
+		foreach ( W4PL_Starter_Templates::get_registry() as $id => $starter ) {
+			$cases[ $id ] = array( $id );
+		}
+		return $cases;
+	}
+
+	/**
+	 * @dataProvider starter_provider
+	 */
+	public function test_starter_renders_to_stable_output( $id ) {
+		$starter = W4PL_Starter_Templates::get( $id );
+
+		$options = W4PL_Starter_Templates::apply(
+			array(
+				'list_type'        => $starter['list_type'],
+				'post_type'        => array( 'post' ),
+				'starter_template' => $id,
+			)
+		);
+
+		$html = $this->render_list( $options );
+
+		$this->assertStringNotContainsString( '[post_title]', $html, "Unparsed tags in starter $id output" );
+		$this->assertMatchesHtmlSnapshot( 'starter-' . $id, $html );
+	}
+}

--- a/tests/class-w4pl-snapshot-testcase.php
+++ b/tests/class-w4pl-snapshot-testcase.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Shared fixtures, normalization and snapshot assertion for rendering tests.
+ *
+ * These snapshots freeze the output of the rendering pipeline for all five
+ * list types. They are the compatibility guarantee for lists stored on
+ * existing sites: a refactor that changes any snapshot is a breaking change
+ * until proven otherwise. Regenerate deliberately with:
+ *
+ *   W4PL_UPDATE_SNAPSHOTS=1 vendor-dev/bin/phpunit --filter ListRenderingTest
+ *
+ * @package W4_Post_List
+ */
+
+abstract class W4PL_Snapshot_TestCase extends WP_UnitTestCase {
+
+	protected static $cat_alpha;
+	protected static $cat_beta;
+	protected static $user_ann;
+	protected static $user_bob;
+	protected static $post_ids = array();
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$cat_alpha = $factory->term->create(
+			array(
+				'taxonomy' => 'category',
+				'name'     => 'Alpha',
+				'slug'     => 'alpha',
+			)
+		);
+		self::$cat_beta  = $factory->term->create(
+			array(
+				'taxonomy' => 'category',
+				'name'     => 'Beta',
+				'slug'     => 'beta',
+			)
+		);
+
+		self::$user_ann = $factory->user->create(
+			array(
+				'role'         => 'author',
+				'user_login'   => 'ann',
+				'display_name' => 'Ann Author',
+			)
+		);
+		self::$user_bob = $factory->user->create(
+			array(
+				'role'         => 'author',
+				'user_login'   => 'bob',
+				'display_name' => 'Bob Builder',
+			)
+		);
+
+		$fixtures = array(
+			array( 'Winter release notes', '2026-01-05 09:00:00', self::$cat_alpha, self::$user_ann ),
+			array( 'Spring cleaning tips', '2026-04-10 10:00:00', self::$cat_beta, self::$user_bob ),
+			array( 'Year in review', '2025-09-14 12:00:00', self::$cat_alpha, self::$user_ann ),
+			array( 'Interview with a builder', '2025-06-21 08:30:00', self::$cat_beta, self::$user_bob ),
+			array( 'Ten tips for faster sites', '2024-11-02 15:00:00', self::$cat_alpha, self::$user_ann ),
+			array( 'Hello from the archive', '2024-03-10 11:00:00', self::$cat_beta, self::$user_bob ),
+		);
+
+		foreach ( $fixtures as $f ) {
+			self::$post_ids[] = $factory->post->create(
+				array(
+					'post_title'    => $f[0],
+					'post_date'     => $f[1],
+					'post_category' => array( $f[2] ),
+					'post_author'   => $f[3],
+					'post_content'  => 'Fixture content for ' . $f[0] . '.',
+					'post_excerpt'  => 'Excerpt for ' . $f[0] . '.',
+				)
+			);
+		}
+	}
+
+	/**
+	 * Render a list from an options array through the same path the
+	 * [postlist] shortcode uses: a real w4pl post with _w4pl meta.
+	 */
+	protected function render_list( array $options ) {
+		$list_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'w4pl',
+				'post_title'  => 'Characterization list',
+				'post_status' => 'publish',
+			)
+		);
+		update_post_meta( $list_id, '_w4pl', $options );
+
+		return do_shortcode( '[postlist id="' . $list_id . '"]' );
+	}
+
+	/**
+	 * Strip run-dependent identifiers so snapshots are stable across runs.
+	 */
+	protected function normalize( $html ) {
+		$patterns = array(
+			'/W4PL_List_\d+/'                 => 'W4PL_List_{ID}',
+			'/w4pl-list-\d+/'                 => 'w4pl-list-{ID}',
+			'/w4pl-inner-\d+/'                => 'w4pl-inner-{ID}',
+			'/w4pl-css-\d+/'                  => 'w4pl-css-{ID}',
+			'/w4pl-js-\d+/'                   => 'w4pl-js-{ID}',
+			'/w4pl-\d+/'                      => 'w4pl-{ID}',
+			'/\?p=\d+/'                       => '?p={ID}',
+			'/\?page_id=\d+/'                 => '?page_id={ID}',
+			'/\?cat=\d+/'                     => '?cat={ID}',
+			'/\?author=\d+/'                  => '?author={ID}',
+			'/page\d+=(\d+)/'                 => 'page{ID}=$1',
+			'/\b(post|tag|category|user|term)[-_]item[-_]\d+/' => '$1-item-{ID}',
+			'/\bpost-\d+\b/'                  => 'post-{ID}',
+			'/\btag-\d+\b/'                   => 'tag-{ID}',
+			'/[\'"]https?:\/\/[^\'"]*gravatar[^\'"]*[\'"]/' => '"{AVATAR_URL}"',
+		);
+
+		$html = preg_replace( array_keys( $patterns ), array_values( $patterns ), $html );
+
+		// Trim per-line trailing whitespace; keep structure otherwise.
+		$html = preg_replace( '/[ \t]+$/m', '', $html );
+
+		return trim( $html ) . "\n";
+	}
+
+	protected function assertMatchesHtmlSnapshot( $name, $html ) {
+		$normalized = $this->normalize( $html );
+		$dir        = __DIR__ . '/snapshots';
+		$file       = $dir . '/' . $name . '.html';
+
+		if ( getenv( 'W4PL_UPDATE_SNAPSHOTS' ) ) {
+			if ( ! is_dir( $dir ) ) {
+				mkdir( $dir, 0777, true );
+			}
+			file_put_contents( $file, $normalized );
+		}
+
+		$this->assertFileExists( $file, "Snapshot '$name' missing. Generate with W4PL_UPDATE_SNAPSHOTS=1." );
+		$this->assertSame( file_get_contents( $file ), $normalized, "Rendered HTML diverged from snapshot '$name'." );
+	}
+}

--- a/tests/class-w4pl-snapshot-testcase.php
+++ b/tests/class-w4pl-snapshot-testcase.php
@@ -7,7 +7,7 @@
  * existing sites: a refactor that changes any snapshot is a breaking change
  * until proven otherwise. Regenerate deliberately with:
  *
- *   W4PL_UPDATE_SNAPSHOTS=1 vendor-dev/bin/phpunit --filter ListRenderingTest
+ *   W4PL_UPDATE_SNAPSHOTS=1 vendor-dev/bin/phpunit
  *
  * @package W4_Post_List
  */

--- a/tests/snapshots/legacy-preset-simple-list.html
+++ b/tests/snapshots/legacy-preset-simple-list.html
@@ -1,0 +1,19 @@
+<!--W4PL_List_{ID}-->
+<div id="w4pl-list-{ID}" class="w4pl">
+	<div id="w4pl-inner-{ID}" class="w4pl-inner">
+		<ul>
+					<li class="post-item-{ID}"><a href="http://example.org/?p={ID}">Spring cleaning tips</a></li>
+
+					<li class="post-item-{ID}"><a href="http://example.org/?p={ID}">Winter release notes</a></li>
+
+					<li class="post-item-{ID}"><a href="http://example.org/?p={ID}">Year in review</a></li>
+
+					<li class="post-item-{ID}"><a href="http://example.org/?p={ID}">Interview with a builder</a></li>
+
+					<li class="post-item-{ID}"><a href="http://example.org/?p={ID}">Ten tips for faster sites</a></li>
+
+					<li class="post-item-{ID}"><a href="http://example.org/?p={ID}">Hello from the archive</a></li>
+				</ul>
+	</div><!--#w4pl-inner-{ID}-->
+</div><!--#w4pl-{ID}-->
+<!--END_W4PL_List_{ID}-->

--- a/tests/snapshots/starter-authors-posts.html
+++ b/tests/snapshots/starter-authors-posts.html
@@ -1,0 +1,114 @@
+<!--W4PL_List_{ID}-->
+<style id="w4pl-css-{ID}" type="text/css">#w4pl-list-{ID} .w4pl-author-sections {
+	display: flex;
+	flex-direction: column;
+	gap: 2em;
+}
+#w4pl-list-{ID} .author-heading {
+	display: flex;
+	align-items: center;
+	gap: 0.75em;
+	padding-bottom: 0.5em;
+	border-bottom: 1px solid #e5e5e5;
+}
+#w4pl-list-{ID} .user-avatar img {
+	border-radius: 50%;
+	width: 48px;
+	height: 48px;
+}
+#w4pl-list-{ID} .user-name {
+	margin: 0;
+}
+#w4pl-list-{ID} .author-posts {
+	list-style: none;
+	margin: 0.75em 0 0;
+	padding: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 0.5em;
+}
+#w4pl-list-{ID} .post-item {
+	display: flex;
+	align-items: baseline;
+	justify-content: space-between;
+	gap: 1em;
+}
+#w4pl-list-{ID} .post-date {
+	color: #888;
+	font-size: 0.875em;
+	white-space: nowrap;
+}</style>
+<div id="w4pl-list-{ID}" class="w4pl">
+	<div id="w4pl-inner-{ID}" class="w4pl-inner">
+		<div class="w4pl-author-sections">
+
+	<section class="user-item">
+		<div class="author-heading">
+			<span class="user-avatar"><img alt='' src="{AVATAR_URL}" srcset="{AVATAR_URL}" class='avatar avatar-96 photo' height='96' width='96' loading='lazy' decoding='async'/></span>
+			<h3 class="user-name">
+				<a href="http://example.org/?author={ID}">admin</a>
+			</h3>
+		</div>
+		<ul class="author-posts">
+
+		</ul>
+	</section>
+
+	<section class="user-item">
+		<div class="author-heading">
+			<span class="user-avatar"><img alt='' src="{AVATAR_URL}" srcset="{AVATAR_URL}" class='avatar avatar-96 photo' height='96' width='96' loading='lazy' decoding='async'/></span>
+			<h3 class="user-name">
+				<a href="http://example.org/?author={ID}">Ann Author</a>
+			</h3>
+		</div>
+		<ul class="author-posts">
+
+			<li class="post-item">
+				<a class="post-title" href="http://example.org/?p={ID}">Winter release notes</a>
+				<span class="post-date">Jan 5, 2026</span>
+			</li>
+
+			<li class="post-item">
+				<a class="post-title" href="http://example.org/?p={ID}">Year in review</a>
+				<span class="post-date">Sep 14, 2025</span>
+			</li>
+
+			<li class="post-item">
+				<a class="post-title" href="http://example.org/?p={ID}">Ten tips for faster sites</a>
+				<span class="post-date">Nov 2, 2024</span>
+			</li>
+
+		</ul>
+	</section>
+
+	<section class="user-item">
+		<div class="author-heading">
+			<span class="user-avatar"><img alt='' src="{AVATAR_URL}" srcset="{AVATAR_URL}" class='avatar avatar-96 photo' height='96' width='96' loading='lazy' decoding='async'/></span>
+			<h3 class="user-name">
+				<a href="http://example.org/?author={ID}">Bob Builder</a>
+			</h3>
+		</div>
+		<ul class="author-posts">
+
+			<li class="post-item">
+				<a class="post-title" href="http://example.org/?p={ID}">Spring cleaning tips</a>
+				<span class="post-date">Apr 10, 2026</span>
+			</li>
+
+			<li class="post-item">
+				<a class="post-title" href="http://example.org/?p={ID}">Interview with a builder</a>
+				<span class="post-date">Jun 21, 2025</span>
+			</li>
+
+			<li class="post-item">
+				<a class="post-title" href="http://example.org/?p={ID}">Hello from the archive</a>
+				<span class="post-date">Mar 10, 2024</span>
+			</li>
+
+		</ul>
+	</section>
+
+</div>
+	</div><!--#w4pl-inner-{ID}-->
+</div><!--#w4pl-{ID}-->
+<!--END_W4PL_List_{ID}-->

--- a/tests/snapshots/starter-category-index.html
+++ b/tests/snapshots/starter-category-index.html
@@ -1,0 +1,53 @@
+<!--W4PL_List 39-->
+<style id="w4pl-css-{ID}" type="text/css">#w4pl-list-{ID} .w4pl-category-index {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+	gap: 0.5em 1.5em;
+}
+#w4pl-list-{ID} .term-item {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 0.5em;
+	padding: 0.35em 0;
+	border-bottom: 1px solid #eee;
+}
+#w4pl-list-{ID} .term-name {
+	text-decoration: none;
+}
+#w4pl-list-{ID} .term-name:hover {
+	text-decoration: underline;
+}
+#w4pl-list-{ID} .term-count {
+	font-size: 0.8em;
+	background: #f2f2f2;
+	color: #666;
+	border-radius: 999px;
+	padding: 0.1em 0.6em;
+}</style>
+<div id="w4pl-list-{ID}" class="w4pl">
+	<div id="w4pl-inner-{ID}" class="w4pl-inner">
+		<ul class="w4pl-category-index">
+
+	<li class="term-item">
+		<a class="term-name" href="http://example.org/?cat={ID}">Alpha</a>
+		<span class="term-count">3</span>
+	</li>
+
+	<li class="term-item">
+		<a class="term-name" href="http://example.org/?cat={ID}">Beta</a>
+		<span class="term-count">3</span>
+	</li>
+
+	<li class="term-item">
+		<a class="term-name" href="http://example.org/?cat={ID}">Uncategorized</a>
+		<span class="term-count">0</span>
+	</li>
+
+</ul>
+	</div><!--#w4pl-inner-{ID}-->
+</div><!--#w4pl-{ID}-->
+<!--end W4PL_List 39-->

--- a/tests/snapshots/starter-category-posts-index.html
+++ b/tests/snapshots/starter-category-posts-index.html
@@ -1,0 +1,82 @@
+<!--W4PL_List_{ID}-->
+<style id="w4pl-css-{ID}" type="text/css">#w4pl-list-{ID} .w4pl-category-index {
+	display: flex;
+	flex-direction: column;
+	gap: 1.5em;
+}
+#w4pl-list-{ID} .term-item {
+	padding-bottom: 1em;
+	border-bottom: 1px solid #e5e5e5;
+}
+#w4pl-list-{ID} .term-name {
+	margin: 0 0 0.5em;
+}
+#w4pl-list-{ID} .term-name a {
+	text-decoration: none;
+}
+#w4pl-list-{ID} .term-posts {
+	margin: 0;
+	padding-left: 1.25em;
+}
+#w4pl-list-{ID} .post-item {
+	margin: 0.25em 0;
+}</style>
+<div id="w4pl-list-{ID}" class="w4pl">
+	<div id="w4pl-inner-{ID}" class="w4pl-inner">
+		<div class="w4pl-category-index">
+
+	<section class="term-item">
+		<h3 class="term-name">
+			<a href="http://example.org/?cat={ID}">Alpha</a>
+		</h3>
+		<ul class="term-posts">
+
+			<li class="post-item">
+				<a class="post-title" href="http://example.org/?p={ID}">Ten tips for faster sites</a>
+			</li>
+
+			<li class="post-item">
+				<a class="post-title" href="http://example.org/?p={ID}">Winter release notes</a>
+			</li>
+
+			<li class="post-item">
+				<a class="post-title" href="http://example.org/?p={ID}">Year in review</a>
+			</li>
+
+		</ul>
+	</section>
+
+	<section class="term-item">
+		<h3 class="term-name">
+			<a href="http://example.org/?cat={ID}">Beta</a>
+		</h3>
+		<ul class="term-posts">
+
+			<li class="post-item">
+				<a class="post-title" href="http://example.org/?p={ID}">Hello from the archive</a>
+			</li>
+
+			<li class="post-item">
+				<a class="post-title" href="http://example.org/?p={ID}">Interview with a builder</a>
+			</li>
+
+			<li class="post-item">
+				<a class="post-title" href="http://example.org/?p={ID}">Spring cleaning tips</a>
+			</li>
+
+		</ul>
+	</section>
+
+	<section class="term-item">
+		<h3 class="term-name">
+			<a href="http://example.org/?cat={ID}">Uncategorized</a>
+		</h3>
+		<ul class="term-posts">
+
+		</ul>
+	</section>
+
+</div>
+	</div><!--#w4pl-inner-{ID}-->
+</div><!--#w4pl-{ID}-->
+<!--END_W4PL_List_{ID}-->

--- a/tests/snapshots/starter-simple-list.html
+++ b/tests/snapshots/starter-simple-list.html
@@ -1,0 +1,43 @@
+<!--W4PL_List_{ID}-->
+<style id="w4pl-css-{ID}" type="text/css">#w4pl-list-{ID} .simple-list-items {
+	margin: 0;
+	padding-left: 1.25em;
+}
+#w4pl-list-{ID} .post-item {
+	margin-bottom: 0.5em;
+}</style>
+<div id="w4pl-list-{ID}" class="w4pl">
+	<div id="w4pl-inner-{ID}" class="w4pl-inner">
+		<div class="w4pl-simple-list">
+	<ul class="simple-list-items">
+
+		<li class="post-item">
+			<a class="post-title" href="http://example.org/?p={ID}">Spring cleaning tips</a>
+		</li>
+
+		<li class="post-item">
+			<a class="post-title" href="http://example.org/?p={ID}">Winter release notes</a>
+		</li>
+
+		<li class="post-item">
+			<a class="post-title" href="http://example.org/?p={ID}">Year in review</a>
+		</li>
+
+		<li class="post-item">
+			<a class="post-title" href="http://example.org/?p={ID}">Interview with a builder</a>
+		</li>
+
+		<li class="post-item">
+			<a class="post-title" href="http://example.org/?p={ID}">Ten tips for faster sites</a>
+		</li>
+
+		<li class="post-item">
+			<a class="post-title" href="http://example.org/?p={ID}">Hello from the archive</a>
+		</li>
+
+	</ul>
+
+</div>
+	</div><!--#w4pl-inner-{ID}-->
+</div><!--#w4pl-{ID}-->
+<!--END_W4PL_List_{ID}-->

--- a/tests/snapshots/starter-thumbnail-cards.html
+++ b/tests/snapshots/starter-thumbnail-cards.html
@@ -1,0 +1,113 @@
+<!--W4PL_List_{ID}-->
+<style id="w4pl-css-{ID}" type="text/css">#w4pl-list-{ID} .w4pl-cards {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+	gap: 1.5em;
+}
+#w4pl-list-{ID} .post-item {
+	display: flex;
+	flex-direction: column;
+	border: 1px solid #e5e5e5;
+	border-radius: 6px;
+	overflow: hidden;
+}
+#w4pl-list-{ID} .post-thumb {
+	display: block;
+	line-height: 0;
+}
+#w4pl-list-{ID} .post-thumb img {
+	width: 100%;
+	height: auto;
+}
+#w4pl-list-{ID} .post-title {
+	margin: 0.75em 1em 0.25em;
+	font-size: 1.1em;
+}
+#w4pl-list-{ID} .post-title a {
+	text-decoration: none;
+}
+#w4pl-list-{ID} .post-excerpt {
+	margin: 0 1em 1em;
+	font-size: 0.9em;
+	color: #666;
+}</style>
+<div id="w4pl-list-{ID}" class="w4pl">
+	<div id="w4pl-inner-{ID}" class="w4pl-inner">
+		<div class="w4pl-cards">
+
+	<div class="post-item">
+		<a class="post-thumb" href="http://example.org/?p={ID}">
+
+		</a>
+		<h3 class="post-title">
+			<a href="http://example.org/?p={ID}">Spring cleaning tips</a>
+		</h3>
+		<div class="post-excerpt">
+			Excerpt for Spring cleaning tips.
+		</div>
+	</div>
+
+	<div class="post-item">
+		<a class="post-thumb" href="http://example.org/?p={ID}">
+
+		</a>
+		<h3 class="post-title">
+			<a href="http://example.org/?p={ID}">Winter release notes</a>
+		</h3>
+		<div class="post-excerpt">
+			Excerpt for Winter release notes.
+		</div>
+	</div>
+
+	<div class="post-item">
+		<a class="post-thumb" href="http://example.org/?p={ID}">
+
+		</a>
+		<h3 class="post-title">
+			<a href="http://example.org/?p={ID}">Year in review</a>
+		</h3>
+		<div class="post-excerpt">
+			Excerpt for Year in review.
+		</div>
+	</div>
+
+	<div class="post-item">
+		<a class="post-thumb" href="http://example.org/?p={ID}">
+
+		</a>
+		<h3 class="post-title">
+			<a href="http://example.org/?p={ID}">Interview with a builder</a>
+		</h3>
+		<div class="post-excerpt">
+			Excerpt for Interview with a builder.
+		</div>
+	</div>
+
+	<div class="post-item">
+		<a class="post-thumb" href="http://example.org/?p={ID}">
+
+		</a>
+		<h3 class="post-title">
+			<a href="http://example.org/?p={ID}">Ten tips for faster sites</a>
+		</h3>
+		<div class="post-excerpt">
+			Excerpt for Ten tips for faster sites.
+		</div>
+	</div>
+
+	<div class="post-item">
+		<a class="post-thumb" href="http://example.org/?p={ID}">
+
+		</a>
+		<h3 class="post-title">
+			<a href="http://example.org/?p={ID}">Hello from the archive</a>
+		</h3>
+		<div class="post-excerpt">
+			Excerpt for Hello from the archive.
+		</div>
+	</div>
+
+</div>
+	</div><!--#w4pl-inner-{ID}-->
+</div><!--#w4pl-{ID}-->
+<!--END_W4PL_List_{ID}-->

--- a/tests/snapshots/starter-title-date-list.html
+++ b/tests/snapshots/starter-title-date-list.html
@@ -55,7 +55,6 @@
 		<span class="post-date">Mar 10, 2024</span>
 	</div>
 
-
 </div>
 	</div><!--#w4pl-inner-{ID}-->
 </div><!--#w4pl-{ID}-->

--- a/tests/snapshots/starter-title-date-list.html
+++ b/tests/snapshots/starter-title-date-list.html
@@ -1,0 +1,62 @@
+<!--W4PL_List_{ID}-->
+<style id="w4pl-css-{ID}" type="text/css">#w4pl-list-{ID} .w4pl-title-date-list .post-item {
+	display: flex;
+	align-items: baseline;
+	justify-content: space-between;
+	gap: 1em;
+	padding: 0.6em 0;
+	border-bottom: 1px solid #e5e5e5;
+}
+#w4pl-list-{ID} .w4pl-title-date-list .post-item:last-of-type {
+	border-bottom: none;
+}
+#w4pl-list-{ID} .w4pl-title-date-list .post-title {
+	text-decoration: none;
+}
+#w4pl-list-{ID} .w4pl-title-date-list .post-title:hover {
+	text-decoration: underline;
+}
+#w4pl-list-{ID} .w4pl-title-date-list .post-date {
+	white-space: nowrap;
+	color: #777;
+	font-size: 0.875em;
+}</style>
+<div id="w4pl-list-{ID}" class="w4pl">
+	<div id="w4pl-inner-{ID}" class="w4pl-inner">
+		<div class="w4pl-title-date-list">
+
+	<div class="post-item">
+		<a class="post-title" href="http://example.org/?p={ID}">Spring cleaning tips</a>
+		<span class="post-date">Apr 10, 2026</span>
+	</div>
+
+	<div class="post-item">
+		<a class="post-title" href="http://example.org/?p={ID}">Winter release notes</a>
+		<span class="post-date">Jan 5, 2026</span>
+	</div>
+
+	<div class="post-item">
+		<a class="post-title" href="http://example.org/?p={ID}">Year in review</a>
+		<span class="post-date">Sep 14, 2025</span>
+	</div>
+
+	<div class="post-item">
+		<a class="post-title" href="http://example.org/?p={ID}">Interview with a builder</a>
+		<span class="post-date">Jun 21, 2025</span>
+	</div>
+
+	<div class="post-item">
+		<a class="post-title" href="http://example.org/?p={ID}">Ten tips for faster sites</a>
+		<span class="post-date">Nov 2, 2024</span>
+	</div>
+
+	<div class="post-item">
+		<a class="post-title" href="http://example.org/?p={ID}">Hello from the archive</a>
+		<span class="post-date">Mar 10, 2024</span>
+	</div>
+
+
+</div>
+	</div><!--#w4pl-inner-{ID}-->
+</div><!--#w4pl-{ID}-->
+<!--END_W4PL_List_{ID}-->

--- a/tests/snapshots/starter-user-directory.html
+++ b/tests/snapshots/starter-user-directory.html
@@ -1,0 +1,60 @@
+<!--W4PL_List_{ID}-->
+<style id="w4pl-css-{ID}" type="text/css">#w4pl-list-{ID} .w4pl-user-directory {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+	gap: 1.25em;
+}
+#w4pl-list-{ID} .user-item {
+	text-align: center;
+	padding: 1.5em 1em;
+	border: 1px solid #e5e5e5;
+	border-radius: 8px;
+}
+#w4pl-list-{ID} .user-avatar img {
+	border-radius: 50%;
+	max-width: 100%;
+	height: auto;
+}
+#w4pl-list-{ID} .user-name {
+	margin: 0.75em 0 0.25em;
+}
+#w4pl-list-{ID} .user-name a {
+	text-decoration: none;
+}
+#w4pl-list-{ID} .user-bio {
+	margin: 0;
+	font-size: 0.9em;
+	color: #666;
+}</style>
+<div id="w4pl-list-{ID}" class="w4pl">
+	<div id="w4pl-inner-{ID}" class="w4pl-inner">
+		<div class="w4pl-user-directory">
+
+	<div class="user-item">
+		<div class="user-avatar"><img alt='' src="{AVATAR_URL}" srcset="{AVATAR_URL}" class='avatar avatar-96 photo' height='96' width='96' loading='lazy' decoding='async'/></div>
+		<h3 class="user-name">
+			<a href="http://example.org/?author={ID}">admin</a>
+		</h3>
+		<p class="user-bio"></p>
+	</div>
+
+	<div class="user-item">
+		<div class="user-avatar"><img alt='' src="{AVATAR_URL}" srcset="{AVATAR_URL}" class='avatar avatar-96 photo' height='96' width='96' loading='lazy' decoding='async'/></div>
+		<h3 class="user-name">
+			<a href="http://example.org/?author={ID}">Ann Author</a>
+		</h3>
+		<p class="user-bio"></p>
+	</div>
+
+	<div class="user-item">
+		<div class="user-avatar"><img alt='' src="{AVATAR_URL}" srcset="{AVATAR_URL}" class='avatar avatar-96 photo' height='96' width='96' loading='lazy' decoding='async'/></div>
+		<h3 class="user-name">
+			<a href="http://example.org/?author={ID}">Bob Builder</a>
+		</h3>
+		<p class="user-bio"></p>
+	</div>
+
+</div>
+	</div><!--#w4pl-inner-{ID}-->
+</div><!--#w4pl-{ID}-->
+<!--END_W4PL_List_{ID}-->

--- a/tests/snapshots/starter-year-archive.html
+++ b/tests/snapshots/starter-year-archive.html
@@ -1,0 +1,90 @@
+<!--W4PL_List_{ID}-->
+<style id="w4pl-css-{ID}" type="text/css">#w4pl-list-{ID} .w4pl-year-archive {
+	display: flex;
+	flex-direction: column;
+	gap: 2em;
+}
+#w4pl-list-{ID} .group-title {
+	margin: 0 0 0.5em;
+	padding-bottom: 0.3em;
+	border-bottom: 1px solid #e0e0e0;
+}
+#w4pl-list-{ID} .archive-posts {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 0.5em;
+}
+#w4pl-list-{ID} .post-item {
+	display: flex;
+	justify-content: space-between;
+	align-items: baseline;
+	gap: 1em;
+}
+#w4pl-list-{ID} .post-date {
+	color: #888;
+	font-size: 0.875em;
+	white-space: nowrap;
+}</style>
+<div id="w4pl-list-{ID}" class="w4pl">
+	<div id="w4pl-inner-{ID}" class="w4pl-inner">
+		<div class="w4pl-year-archive">
+
+	<section class="group-item">
+		<h3 class="group-title">2026</h3>
+		<ul class="archive-posts">
+
+			<li class="post-item">
+				<a class="post-title" href="http://example.org/?p={ID}">Spring cleaning tips</a>
+				<span class="post-date">April 10</span>
+			</li>
+
+			<li class="post-item">
+				<a class="post-title" href="http://example.org/?p={ID}">Winter release notes</a>
+				<span class="post-date">January 5</span>
+			</li>
+
+		</ul>
+	</section>
+
+	<section class="group-item">
+		<h3 class="group-title">2025</h3>
+		<ul class="archive-posts">
+
+			<li class="post-item">
+				<a class="post-title" href="http://example.org/?p={ID}">Year in review</a>
+				<span class="post-date">September 14</span>
+			</li>
+
+			<li class="post-item">
+				<a class="post-title" href="http://example.org/?p={ID}">Interview with a builder</a>
+				<span class="post-date">June 21</span>
+			</li>
+
+		</ul>
+	</section>
+
+	<section class="group-item">
+		<h3 class="group-title">2024</h3>
+		<ul class="archive-posts">
+
+			<li class="post-item">
+				<a class="post-title" href="http://example.org/?p={ID}">Ten tips for faster sites</a>
+				<span class="post-date">November 2</span>
+			</li>
+
+			<li class="post-item">
+				<a class="post-title" href="http://example.org/?p={ID}">Hello from the archive</a>
+				<span class="post-date">March 10</span>
+			</li>
+
+		</ul>
+	</section>
+
+
+</div>
+	</div><!--#w4pl-inner-{ID}-->
+</div><!--#w4pl-{ID}-->
+<!--END_W4PL_List_{ID}-->

--- a/w4-post-list.php
+++ b/w4-post-list.php
@@ -3,7 +3,7 @@
  * Plugin Name: W4 Post List
  * Plugin URI: https://w4dev.com/plugins/w4-post-list
  * Description: Create lists of posts, terms and users — grouped archives, taxonomy indexes and user directories — placed anywhere with the block, [postlist] shortcode or widget.
- * Version: 2.8.0
+ * Version: 2.9.0
  * Requires at least: 5.8
  * Requires PHP: 7.4
  * Author: Shazzad Hossain Khan


### PR DESCRIPTION
## Summary
- **"Start from a template"** replaces the opaque preset flow for new lists: picking one of **8 ready-made layouts** copies editable markup + scoped CSS into the visible Template/Style fields and sets the options it needs (Group by, per-author limit, taxonomy, ordering). One-shot, never persisted, applied in the editor path and defensively on save (closes the pick-then-publish race). Silent overwrite per maintainer decision.
- **Library** (all in the plain dialect with wrapper-class conventions, CSS scoped to `#w4pl-list-[listid]`): simple list, thumbnail cards, title & date list, year archive, category index, category index with posts, user directory, authors with posts. Filterable via `w4pl/starter_templates` with shape normalization (malformed third-party entries are dropped, never warn). `thumbnail` key reserved for M7 previews.
- **Legacy presets frozen**: lists storing a `preset` key keep the old field, hiding behavior, and render-time override — byte-frozen by a new snapshot test.
- **Telemetry**: `starter_applied` counter (opt-in Appsero pipeline) feeds the M6 success metric.
- Review hardening: crafted array input guard (PHP 8 TypeError path), `esc_attr` on select values in the form engine, stale-starter reset on failed form refresh, `HTTP_HOST` guard in the form engine.
- Docs per definition-of-done: Getting Started + template-examples mention the picker; readme FAQ "Do I have to write the template myself?"; changelog.

## Process (ultracode)
8 parallel authoring agents produced the library against a strict tag/CSS/convention spec; a 4-lens adversarial review panel (back-compat, security/i18n, library correctness, completeness) confirmed all invariants — apply() unreachable at render, one-shot guaranteed, legacy byte-identical — and its 13 real findings are all fixed (incl. the users.posts `limit` bug and the `:last-of-type`-vs-nav CSS bug). Noted deviation: the roadmap's "A-Z sitemap" layout needs a first-letter groupby that doesn't exist yet — substituted category-index-with-posts; A-Z queued for the groupby milestone.

## Test plan
- [x] 65 tests / 310 assertions green twice (23 new: registry validity incl. tags/scoping/whitelist, apply semantics incl. hostile filter + crafted input, save race, field swap, legacy snapshot, per-starter render snapshots, stats counter)
- [x] Live-site smoke: all 8 starters through the real save pipeline → render with scoped CSS, no unparsed tags (40 checks pass)
- [x] Docs-drift guard extended to the registry
- [ ] CI green on PHP 7.4 + 8.2
- [ ] Manual (for maintainer): pick starters in the editor UI, verify fields populate after the refresh and the select returns to placeholder

Do not merge — awaiting maintainer review per instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)