### PR TITLE
v2.11.0: Save-time validation, editor nonce, type-switch guard, review prompt (M8)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,7 @@
 == Changelog ==
+= 2.10.0 =
+* New: Live preview in the list editor - a Preview button renders your current, unsaved settings in an isolated pane, refreshing automatically after option changes. No more publish-and-reload loops while designing a list.
+* Improved: Getting Started guide mentions the preview workflow.
 = 2.9.0 =
 * New: "Start from a template" - pick from 8 ready-made layouts (simple list, thumbnail cards, title & date list, year archive, category index, category index with posts, user directory, authors with posts). Picking one copies editable markup and styles into the Template and Style fields and sets the options it needs, like Group by. Developers can add layouts via the w4pl/starter_templates filter.
 * Improved: Lists using a legacy preset keep working exactly as before; the legacy preset field only appears on those lists.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,10 @@
 == Changelog ==
+= 2.11.0 =
+* New: The editor now catches mistakes at save time - non-numeric values in numeric fields are coerced with a clear warning, unknown template tags get a "did you mean" suggestion, and a template missing its loop tag warns before rendering blank.
+* New: Switching list type with an incompatible template shows an inline warning with a one-click "Replace with the default template" fix.
+* New: The list editor form is protected by a nonce; quick edit, bulk edit and autosave can never touch list options.
+* Improved: "Any" post status now excludes the concrete statuses automatically.
+* New: A once-only review request appears a week after your first published list. One click dismisses it forever.
 = 2.10.0 =
 * New: Live preview in the list editor - a Preview button renders your current, unsaved settings in an isolated pane, refreshing automatically after option changes. No more publish-and-reload loops while designing a list.
 * Improved: Getting Started guide mentions the preview workflow.

--- a/admin/class-admin-list-editor.php
+++ b/admin/class-admin-list-editor.php
@@ -62,7 +62,12 @@ class W4PL_List_Editor {
 			'w4pl_list_editor',
 			'w4plListEditor',
 			array(
-				'refreshFailed' => __( 'Could not refresh the form. Your entries are unchanged — check your connection and try again.', 'w4-post-list' ),
+				'refreshFailed'  => __( 'Could not refresh the form. Your entries are unchanged — check your connection and try again.', 'w4-post-list' ),
+				'previewNonce'   => wp_create_nonce( 'w4pl_preview' ),
+				'previewLoading' => __( 'Rendering preview…', 'w4-post-list' ),
+				'previewFailed'  => __( 'Preview failed — check your connection and try again.', 'w4-post-list' ),
+				'previewHide'    => __( 'Hide preview', 'w4-post-list' ),
+				'previewShow'    => __( 'Preview', 'w4-post-list' ),
 			)
 		);
 		wp_enqueue_style( 'w4pl_form' );

--- a/admin/class-admin-lists-metaboxes.php
+++ b/admin/class-admin-lists-metaboxes.php
@@ -169,6 +169,14 @@ class W4PL_Admin_Lists_Metaboxes {
 		}
 
 		if ( ! isset( $_POST['w4pl'] ) ) {
+			// Quick-edit, bulk-edit and REST saves post no options; leave the
+			// stored options untouched.
+			return;
+		}
+
+		// The nonce is only demanded when list options are actually posted,
+		// and an invalid one bails without wiping anything.
+		if ( ! isset( $_POST['w4pl_options_nonce'] ) || ! wp_verify_nonce( sanitize_key( wp_unslash( $_POST['w4pl_options_nonce'] ) ), 'w4pl_save_options' ) ) {
 			return;
 		}
 

--- a/admin/class-admin-lists-metaboxes.php
+++ b/admin/class-admin-lists-metaboxes.php
@@ -188,7 +188,7 @@ class W4PL_Admin_Lists_Metaboxes {
 	 * @param array $options List options.
 	 * @return array
 	 */
-	public function sanitize_options( $options ) {
+	public static function sanitize_options( $options ) {
 		// Sanitize options.
 		foreach ( array( 'no_items_text' ) as $key ) {
 			if ( array_key_exists( $key, $options ) ) {

--- a/admin/class-admin-onboarding.php
+++ b/admin/class-admin-onboarding.php
@@ -21,10 +21,77 @@ class W4PL_Admin_Onboarding {
 	public function __construct() {
 		add_action( 'admin_init', array( $this, 'maybe_create_sample_list' ) );
 		add_action( 'admin_init', array( $this, 'maybe_dismiss_welcome' ) );
+		add_action( 'admin_init', array( $this, 'maybe_dismiss_review_prompt' ) );
 		add_action( 'admin_notices', array( $this, 'welcome_notice' ) );
 		add_action( 'admin_notices', array( $this, 'empty_state' ) );
+		add_action( 'admin_notices', array( $this, 'review_prompt' ) );
 		add_action( 'wp_ajax_w4pl_dismiss_welcome', array( $this, 'ajax_dismiss_welcome' ) );
 		add_action( 'current_screen', array( $this, 'help_tabs' ) );
+	}
+
+	/**
+	 * Whether the once-only review ask should show: the user published a
+	 * first list at least seven days ago and has not dismissed the ask.
+	 *
+	 * @return bool
+	 */
+	public static function review_prompt_due() {
+		if ( get_option( 'w4pl_review_dismissed' ) ) {
+			return false;
+		}
+
+		$first_publish = (int) get_option( 'w4pl_first_publish_time' );
+
+		return $first_publish && ( time() - $first_publish ) >= 7 * DAY_IN_SECONDS;
+	}
+
+	/**
+	 * Once-only review ask on the Lists screen.
+	 */
+	public function review_prompt() {
+		if ( ! current_user_can( 'edit_pages' ) || ! self::review_prompt_due() ) {
+			return;
+		}
+
+		$screen = get_current_screen();
+		if ( ! $screen || 'edit-w4pl' !== $screen->id ) {
+			return;
+		}
+
+		$dismiss_url = wp_nonce_url( add_query_arg( 'w4pl_dismiss_review', '1' ), 'w4pl_dismiss_review' );
+		?>
+		<div class="notice notice-info">
+			<p>
+				<?php esc_html_e( 'You have been building lists with W4 Post List for a while — a short review on wordpress.org helps other people find the plugin, and helps us keep improving it.', 'w4-post-list' ); ?>
+			</p>
+			<p>
+				<a class="button button-primary" href="https://wordpress.org/support/plugin/w4-post-list/reviews/#new-post" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Leave a review', 'w4-post-list' ); ?></a>
+				<a class="button" href="<?php echo esc_url( $dismiss_url ); ?>"><?php esc_html_e( 'No thanks / already did', 'w4-post-list' ); ?></a>
+			</p>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Permanently dismiss the review ask.
+	 */
+	public function maybe_dismiss_review_prompt() {
+		if ( ! isset( $_GET['w4pl_dismiss_review'] ) ) {
+			return;
+		}
+
+		if ( ! isset( $_GET['_wpnonce'] ) || ! wp_verify_nonce( sanitize_key( wp_unslash( $_GET['_wpnonce'] ) ), 'w4pl_dismiss_review' ) ) {
+			return;
+		}
+
+		if ( ! current_user_can( 'edit_pages' ) ) {
+			return;
+		}
+
+		update_option( 'w4pl_review_dismissed', time(), false );
+
+		wp_safe_redirect( remove_query_arg( array( 'w4pl_dismiss_review', '_wpnonce' ) ) );
+		exit;
 	}
 
 	/**

--- a/admin/class-admin-preview.php
+++ b/admin/class-admin-preview.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Live preview of unsaved list options in the editor.
+ *
+ * @class W4PL_Admin_Preview
+ * @package W4_Post_List
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Renders the current (possibly unsaved) editor options to HTML on demand.
+ */
+class W4PL_Admin_Preview {
+
+	/**
+	 * Constructor
+	 */
+	public function __construct() {
+		add_action( 'wp_ajax_w4pl_list_preview', array( $this, 'ajax_preview' ) );
+		add_action( 'edit_form_after_title', array( $this, 'preview_pane' ), 30 );
+	}
+
+	/**
+	 * Render posted options through the exact pipeline the shortcode uses.
+	 *
+	 * @param  array $options Raw (unslashed) options from the editor form.
+	 * @return string
+	 * @throws Exception When the options cannot produce a list.
+	 */
+	public static function render_preview( array $options ) {
+		$options = W4PL_Admin_Lists_Metaboxes::sanitize_options( $options );
+		$options = apply_filters( 'w4pl/pre_get_options', $options );
+
+		$list = W4PL_List_Factory::get_list( $options );
+
+		return $list->get_html();
+	}
+
+	/**
+	 * AJAX endpoint: nonce + per-post capability checked.
+	 */
+	public function ajax_preview() {
+		check_ajax_referer( 'w4pl_preview', 'nonce' );
+
+		$posted = array();
+		if ( isset( $_POST['w4pl'] ) && is_array( $_POST['w4pl'] ) ) {
+			// Sanitized field-by-field in render_preview() via sanitize_options().
+			$posted = wp_unslash( $_POST['w4pl'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		}
+
+		$list_id = 0;
+		if ( isset( $posted['id'] ) ) {
+			$list_id = (int) $posted['id'];
+		}
+
+		if ( ! $list_id || ! current_user_can( 'edit_post', $list_id ) ) {
+			wp_send_json_error(
+				array( 'message' => __( 'You do not have permission to preview this list.', 'w4-post-list' ) ),
+				403
+			);
+		}
+
+		// Only the render is guarded; the send calls stay outside so their
+		// terminating behavior is never swallowed by this catch.
+		try {
+			$html = self::render_preview( $posted );
+		} catch ( Exception $e ) {
+			wp_send_json_error( array( 'message' => $e->getMessage() ) );
+		}
+
+		wp_send_json_success( array( 'html' => $html ) );
+	}
+
+	/**
+	 * Preview region under the editor form. Lives outside #w4pl_list_options
+	 * so it survives the AJAX form replacement.
+	 *
+	 * @param WP_Post $post Current post.
+	 */
+	public function preview_pane( $post ) {
+		if ( ! $post instanceof WP_Post || W4PL_Config::LIST_POST_TYPE !== $post->post_type ) {
+			return;
+		}
+		?>
+		<div id="w4pl_preview_wrap" style="margin-top:12px;">
+			<p style="margin:0 0 8px;">
+				<button type="button" class="button" id="w4pl_preview_toggle" aria-expanded="false" aria-controls="w4pl_preview_pane">
+					<?php esc_html_e( 'Preview', 'w4-post-list' ); ?>
+				</button>
+				<span id="w4pl_preview_status" role="status" style="margin-left:8px;color:#777;"></span>
+			</p>
+			<div id="w4pl_preview_pane" style="display:none;border:1px solid #dcdcde;border-radius:4px;background:#fff;">
+				<iframe id="w4pl_preview_frame" title="<?php esc_attr_e( 'List preview', 'w4-post-list' ); ?>" style="width:100%;height:420px;border:0;"></iframe>
+			</div>
+			<p class="description" style="margin-top:6px;">
+				<?php esc_html_e( 'The preview renders your unsaved settings without your theme\'s styles, so spacing and fonts will differ on the real page.', 'w4-post-list' ); ?>
+			</p>
+		</div>
+		<?php
+	}
+}

--- a/admin/class-admin-validation.php
+++ b/admin/class-admin-validation.php
@@ -1,0 +1,211 @@
+<?php
+/**
+ * Save-time validation: coerce obviously wrong values, warn about template
+ * problems, never reject a save.
+ *
+ * @class W4PL_Admin_Validation
+ * @package W4_Post_List
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Validates list options as they are saved and surfaces warnings.
+ */
+class W4PL_Admin_Validation {
+
+	/**
+	 * Loop tag required per list type (top-level section).
+	 *
+	 * @var array
+	 */
+	private static $required_loop_tags = array(
+		'posts'       => 'posts',
+		'terms'       => 'terms',
+		'users'       => 'users',
+		'terms.posts' => 'terms',
+		'users.posts' => 'users',
+	);
+
+	/**
+	 * Constructor
+	 */
+	public function __construct() {
+		add_filter( 'w4pl/pre_save_options', array( $this, 'validate_on_save' ), 90 );
+		add_action( 'admin_notices', array( $this, 'show_warnings' ) );
+	}
+
+	/**
+	 * Coerce numeric fields and collect warnings. Warn-only by design:
+	 * the save always proceeds so no user input is ever lost.
+	 *
+	 * @param  array $options Options about to be persisted.
+	 * @return array
+	 */
+	public function validate_on_save( $options ) {
+		if ( ! is_array( $options ) ) {
+			return $options;
+		}
+
+		$warnings = array();
+
+		foreach ( array( 'posts_per_page', 'limit', 'offset', 'terms_limit', 'terms_offset', 'terms_max', 'users_limit', 'users_offset', 'users_max' ) as $key ) {
+			if ( ! isset( $options[ $key ] ) || '' === $options[ $key ] || is_numeric( $options[ $key ] ) ) {
+				continue;
+			}
+
+			$coerced = self::coerce_numeric( $options[ $key ] );
+
+			$warnings[] = sprintf(
+				/* translators: 1: field name, 2: entered value, 3: value used instead */
+				__( '"%1$s" expects a number; "%2$s" was read as %3$s.', 'w4-post-list' ),
+				$key,
+				$options[ $key ],
+				( '' === $coerced ) ? __( 'empty', 'w4-post-list' ) : $coerced
+			);
+
+			$options[ $key ] = $coerced;
+		}
+
+		if ( isset( $options['orderby_meta_key'] ) && is_string( $options['orderby_meta_key'] ) ) {
+			$options['orderby_meta_key'] = sanitize_text_field( $options['orderby_meta_key'] );
+		}
+
+		$warnings = array_merge( $warnings, self::template_warnings( $options ) );
+
+		if ( $warnings && ! empty( $options['id'] ) ) {
+			set_transient( 'w4pl_save_warnings_' . (int) $options['id'], $warnings, 120 );
+		}
+
+		return $options;
+	}
+
+	/**
+	 * Leading digits win ("10 posts" -> 10); pure garbage becomes empty
+	 * (falls back to the field's default behavior).
+	 *
+	 * @param  mixed $value Raw value.
+	 * @return string
+	 */
+	public static function coerce_numeric( $value ) {
+		if ( ! is_scalar( $value ) ) {
+			return '';
+		}
+
+		$int = (int) $value;
+
+		if ( 0 === $int && ! preg_match( '/^\s*[0-9]/', (string) $value ) ) {
+			return '';
+		}
+
+		return (string) $int;
+	}
+
+	/**
+	 * Unknown-tag and missing-loop-tag warnings for a template.
+	 *
+	 * @param  array $options List options.
+	 * @return array
+	 */
+	public static function template_warnings( $options ) {
+		$warnings = array();
+
+		if ( empty( $options['template'] ) || ! is_string( $options['template'] ) ) {
+			return $warnings;
+		}
+
+		$registered = array_keys( w4pl_get_shortcodes() );
+
+		preg_match_all( '/\[\/?([a-z_][a-z0-9_]*)/i', $options['template'], $m );
+		$used    = array_unique( $m[1] );
+		$unknown = array_diff( $used, $registered );
+
+		foreach ( $unknown as $tag ) {
+			$suggestion = self::closest_tag( $tag, $registered );
+
+			if ( $suggestion ) {
+				$warnings[] = sprintf(
+					/* translators: 1: unknown tag, 2: suggested tag */
+					__( 'Template tag [%1$s] is not registered and will print as plain text — did you mean [%2$s]?', 'w4-post-list' ),
+					$tag,
+					$suggestion
+				);
+			} else {
+				$warnings[] = sprintf(
+					/* translators: %s: unknown tag */
+					__( 'Template tag [%s] is not registered and will print as plain text.', 'w4-post-list' ),
+					$tag
+				);
+			}
+		}
+
+		if ( isset( $options['list_type'], self::$required_loop_tags[ $options['list_type'] ] ) ) {
+			$loop = self::$required_loop_tags[ $options['list_type'] ];
+
+			if ( false === strpos( $options['template'], '[' . $loop . ']' ) ) {
+				$warnings[] = sprintf(
+					/* translators: 1: loop tag, 2: list type label */
+					__( 'The template has no [%1$s]…[/%1$s] loop, so a "%2$s" list will render nothing. Add the loop or pick a starter template.', 'w4-post-list' ),
+					$loop,
+					$options['list_type']
+				);
+			}
+		}
+
+		return $warnings;
+	}
+
+	/**
+	 * Closest registered tag by edit distance, or empty string.
+	 *
+	 * @param  string $tag        Unknown tag.
+	 * @param  array  $registered Registered tag names.
+	 * @return string
+	 */
+	public static function closest_tag( $tag, $registered ) {
+		$best      = '';
+		$best_dist = 4; // Suggest only near-misses.
+
+		foreach ( $registered as $candidate ) {
+			$dist = levenshtein( strtolower( $tag ), strtolower( $candidate ) );
+
+			if ( $dist < $best_dist ) {
+				$best      = $candidate;
+				$best_dist = $dist;
+			}
+		}
+
+		return $best;
+	}
+
+	/**
+	 * Surface stored warnings on the editor screen after the redirect.
+	 */
+	public function show_warnings() {
+		global $post;
+
+		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+		if ( ! $screen || 'w4pl' !== $screen->id || ! $post instanceof WP_Post ) {
+			return;
+		}
+
+		$warnings = get_transient( 'w4pl_save_warnings_' . $post->ID );
+		if ( ! $warnings ) {
+			return;
+		}
+
+		delete_transient( 'w4pl_save_warnings_' . $post->ID );
+		?>
+		<div class="notice notice-warning is-dismissible">
+			<p><strong><?php esc_html_e( 'Your list was saved, with warnings:', 'w4-post-list' ); ?></strong></p>
+			<ul style="list-style:disc;padding-left:20px;">
+				<?php foreach ( $warnings as $warning ) : ?>
+				<li><?php echo esc_html( $warning ); ?></li>
+				<?php endforeach; ?>
+			</ul>
+		</div>
+		<?php
+	}
+}

--- a/admin/pages/views/html-getting-started.php
+++ b/admin/pages/views/html-getting-started.php
@@ -38,6 +38,7 @@
 	</h3>
 	<p>
 		<?php esc_html_e( 'A default template is applied automatically, so you do not need to touch the Template section to get output. Click Publish.', 'w4-post-list' ); ?>
+		<?php esc_html_e( 'Use the Preview button under the editor at any time to see the rendered list without saving.', 'w4-post-list' ); ?>
 	</p>
 
 	<h3>

--- a/admin/views/html-list-edit-form.php
+++ b/admin/views/html-list-edit-form.php
@@ -15,7 +15,7 @@ $fields = array();
 // Root wrapper.
 $fields['before_list_options'] = array(
 	'position' => '0',
-	'html'     => '<div id="w4pl_list_options" class="w4pl-list-editor">',
+	'html'     => '<div id="w4pl_list_options" class="w4pl-list-editor">' . wp_nonce_field( 'w4pl_save_options', 'w4pl_options_nonce', false, false ),
 );
 $fields['id']                  = array(
 	'position'    => '1.1',
@@ -81,8 +81,32 @@ if ( 'posts' === $w4pl_example_type ) {
 
 $w4pl_examples_html .= '<p style="margin:0.5em 0 0;">' . esc_html__( 'Everything between an opening and closing loop tag (like [posts] and [/posts]) repeats once for every item — put your per-item markup there.', 'w4-post-list' ) . '</p>';
 
+$w4pl_loop_map      = array(
+	'posts'       => 'posts',
+	'terms'       => 'terms',
+	'users'       => 'users',
+	'terms.posts' => 'terms',
+	'users.posts' => 'users',
+);
+$w4pl_type_mismatch = '';
+if ( ! empty( $options['template'] ) && isset( $options['list_type'], $w4pl_loop_map[ $options['list_type'] ] ) ) {
+	$w4pl_needed_loop = $w4pl_loop_map[ $options['list_type'] ];
+	if ( false === strpos( $options['template'], '[' . $w4pl_needed_loop . ']' ) ) {
+		$w4pl_type_mismatch = '<div class="notice notice-warning inline" style="margin:0 0 8px;"><p>'
+			. sprintf(
+				/* translators: %s: loop tag name */
+				esc_html__( 'This template has no [%1$s]…[/%1$s] loop, so this list type will render nothing.', 'w4-post-list' ),
+				esc_html( $w4pl_needed_loop )
+			)
+			. ' <button type="button" class="button button-small" id="w4pl_use_default_template" data-template="'
+			. esc_attr( $w4pl_type_example )
+			. '">' . esc_html__( 'Replace with the default template', 'w4-post-list' ) . '</button>'
+			. '</p></div>';
+	}
+}
+
 $template_html = '
-<div class="wffw wffwi_w4pl_template wffwt_textarea">
+<div class="wffw wffwi_w4pl_template wffwt_textarea">' . $w4pl_type_mismatch . '
 	<p style="margin-top:0px;">
 		<a href="#" class="button w4pl_toggler" data-target="#w4pl_template_examples">' . __( 'Template Example', 'w4-post-list' ) . '</a>
 		<a href="#" class="button w4pl_toggler" data-target="#w4pl_template_buttons">' . __( 'Template Tags', 'w4-post-list' ) . '</a>

--- a/assets/js/list-editor.js
+++ b/assets/js/list-editor.js
@@ -226,6 +226,65 @@
 		});
 	}
 
+	/* ----- Live preview ----- */
+
+	function w4pl_l10n(key, fallback) {
+		if (window.w4plListEditor && window.w4plListEditor[key]) {
+			return window.w4plListEditor[key];
+		}
+		return fallback;
+	}
+
+	function w4pl_refresh_preview() {
+		var pane = $('#w4pl_preview_pane');
+		var status = $('#w4pl_preview_status');
+
+		if (!pane.length || !pane.is(':visible')) {
+			return;
+		}
+
+		w4pl_sync_code_editors();
+		status.text(w4pl_l10n('previewLoading', 'Rendering preview…'));
+
+		var data = $('#w4pl_list_options :input').serialize()
+			+ '&action=w4pl_list_preview'
+			+ '&nonce=' + encodeURIComponent(w4pl_l10n('previewNonce', ''));
+
+		$.post(ajaxurl, data, function (r) {
+			if (r && r.success && r.data && typeof r.data.html === 'string') {
+				var frame = document.getElementById('w4pl_preview_frame');
+				frame.srcdoc = '<!doctype html><html><head><meta charset="utf-8">'
+					+ '<style>body{margin:16px;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;color:#1e1e1e;}img{max-width:100%;height:auto;}</style>'
+					+ '</head><body>' + r.data.html + '</body></html>';
+				status.text('');
+			} else {
+				status.text((r && r.data && r.data.message) ? r.data.message : w4pl_l10n('previewFailed', 'Preview failed.'));
+			}
+		}).fail(function () {
+			status.text(w4pl_l10n('previewFailed', 'Preview failed — check your connection and try again.'));
+		});
+	}
+
+	$(document.body).on('click', '#w4pl_preview_toggle', function () {
+		var pane = $('#w4pl_preview_pane');
+		var open = pane.is(':visible');
+
+		if (open) {
+			pane.hide();
+			$(this).attr('aria-expanded', 'false').text(w4pl_l10n('previewShow', 'Preview'));
+		} else {
+			pane.show();
+			$(this).attr('aria-expanded', 'true').text(w4pl_l10n('previewHide', 'Hide preview'));
+			w4pl_refresh_preview();
+		}
+		return false;
+	});
+
+	/* Keep an open preview in sync after each successful form refresh. */
+	$(document).on('w4pl/form_loaded', function () {
+		w4pl_refresh_preview();
+	});
+
 	/*
 	 * Insert a template tag at the cursor - into the CodeMirror instance when
 	 * one owns the field, or the plain textarea otherwise.

--- a/assets/js/list-editor.js
+++ b/assets/js/list-editor.js
@@ -226,6 +226,32 @@
 		});
 	}
 
+	/* "Any" post status is exclusive of concrete statuses. */
+	$(document.body).on('change', 'input[name="w4pl[post_status][]"]', function () {
+		var boxes = $('input[name="w4pl[post_status][]"]');
+
+		if ('any' === $(this).val() && this.checked) {
+			boxes.not(this).prop('checked', false);
+		} else if (this.checked) {
+			boxes.filter('[value="any"]').prop('checked', false);
+		}
+	});
+
+	/* One-click recovery from a template/list-type mismatch. */
+	$(document.body).on('click', '#w4pl_use_default_template', function () {
+		var tpl = $(this).data('template') || '';
+
+		if (w4plEditors.w4pl_template) {
+			w4plEditors.w4pl_template.setValue(tpl);
+			w4plEditors.w4pl_template.save();
+		} else {
+			$('#w4pl_template').val(tpl);
+		}
+
+		$(this).closest('.notice').remove();
+		return false;
+	});
+
 	/* ----- Live preview ----- */
 
 	function w4pl_l10n(key, fallback) {

--- a/assets/js/list-editor.js
+++ b/assets/js/list-editor.js
@@ -70,6 +70,23 @@
 	$(document).on('w4pl/form_loaded', function (el) {
 		w4pl_init_code_editors();
 		w4pl_adjust_height();
+
+		/*
+		 * A just-applied starter template renders a marker notice; open the
+		 * tab it points at (the Template section) so the copied markup is
+		 * immediately visible instead of hiding behind the tab the user
+		 * happened to be on.
+		 */
+		var marker = $('#w4pl_list_options .w4pl-starter-applied[data-show-tab]').first();
+		if (marker.length) {
+			var target = $('#' + marker.data('show-tab'));
+			if (target.length) {
+				$('.w4pl_field_group').removeClass('w4pl_active');
+				target.addClass('w4pl_active');
+				$('#w4pl_tab_id').val(marker.data('show-tab'));
+			}
+		}
+
 		setTimeout(function () {
 			w4pl_refresh_code_editors();
 			w4pl_adjust_height();

--- a/includes/class-starter-templates.php
+++ b/includes/class-starter-templates.php
@@ -41,7 +41,13 @@ class W4PL_Starter_Templates {
 	 * @return array
 	 */
 	public function apply_on_save( $options ) {
-		return self::apply( $options );
+		$options = self::apply( $options );
+
+		if ( is_array( $options ) ) {
+			unset( $options['_starter_applied'] );
+		}
+
+		return $options;
 	}
 
 	/**
@@ -195,6 +201,10 @@ class W4PL_Starter_Templates {
 		if ( class_exists( 'W4PL_Stats' ) ) {
 			W4PL_Stats::increment( 'starter_applied' );
 		}
+
+		// Editor-only marker so the re-rendered form can confirm the apply
+		// and reveal the Template section; stripped before any save.
+		$options['_starter_applied'] = $starter_id;
 
 		return $options;
 	}

--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -98,6 +98,10 @@ class W4PL_Stats {
 
 		if ( 'publish' === $new_status && 'publish' !== $old_status ) {
 			self::increment( 'lists_published' );
+
+			if ( ! get_option( 'w4pl_first_publish_time' ) ) {
+				update_option( 'w4pl_first_publish_time', time(), false );
+			}
 		}
 	}
 }

--- a/includes/class-w4-post-list.php
+++ b/includes/class-w4-post-list.php
@@ -29,7 +29,7 @@ final class W4_Post_List {
 	 *
 	 * @var string
 	 */
-	public $version = '2.10.0';
+	public $version = '2.11.0';
 
 	/**
 	 * This will hold current class instance
@@ -132,6 +132,7 @@ final class W4_Post_List {
 			include W4PL_DIR . '/admin/class-admin-list-editor.php';
 			include W4PL_DIR . '/admin/class-admin-onboarding.php';
 			include W4PL_DIR . '/admin/class-admin-preview.php';
+			include W4PL_DIR . '/admin/class-admin-validation.php';
 
 			/* Admin pages */
 			foreach ( glob( W4PL_DIR . 'admin/pages/*.php' ) as $file ) {
@@ -175,6 +176,7 @@ final class W4_Post_List {
 			new W4PL_Admin_Lists_Metaboxes();
 			new W4PL_Admin_Onboarding();
 			new W4PL_Admin_Preview();
+			new W4PL_Admin_Validation();
 
 			new W4PL_Admin_Page_Docs();
 		}

--- a/includes/class-w4-post-list.php
+++ b/includes/class-w4-post-list.php
@@ -29,7 +29,7 @@ final class W4_Post_List {
 	 *
 	 * @var string
 	 */
-	public $version = '2.9.0';
+	public $version = '2.10.0';
 
 	/**
 	 * This will hold current class instance
@@ -131,6 +131,7 @@ final class W4_Post_List {
 			include W4PL_DIR . '/admin/class-admin-lists-metaboxes.php';
 			include W4PL_DIR . '/admin/class-admin-list-editor.php';
 			include W4PL_DIR . '/admin/class-admin-onboarding.php';
+			include W4PL_DIR . '/admin/class-admin-preview.php';
 
 			/* Admin pages */
 			foreach ( glob( W4PL_DIR . 'admin/pages/*.php' ) as $file ) {
@@ -173,6 +174,7 @@ final class W4_Post_List {
 			new W4PL_Admin_Lists_Table_Columns();
 			new W4PL_Admin_Lists_Metaboxes();
 			new W4PL_Admin_Onboarding();
+			new W4PL_Admin_Preview();
 
 			new W4PL_Admin_Page_Docs();
 		}

--- a/includes/helpers/class-helper-presets.php
+++ b/includes/helpers/class-helper-presets.php
@@ -63,6 +63,23 @@ class W4PL_Helper_Presets {
 			return $fields;
 		}
 
+		if ( ! empty( $options['_starter_applied'] ) ) {
+			$applied = W4PL_Starter_Templates::get( $options['_starter_applied'] );
+
+			if ( $applied ) {
+				$fields['starter_applied_notice'] = array(
+					'position' => '3.05',
+					'html'     => '<div class="notice notice-success inline w4pl-starter-applied" data-show-tab="w4pl_field_group_template" style="margin:0 0 10px;"><p>'
+						. sprintf(
+							/* translators: %s: starter template label */
+							esc_html__( '"%s" applied — its markup and styles are now in the Template and Style sections, ready to edit.', 'w4-post-list' ),
+							esc_html( $applied['label'] )
+						)
+						. '</p></div>',
+				);
+			}
+		}
+
 		$fields['starter_template'] = array(
 			'position'    => '3.1',
 			'option_name' => 'starter_template',
@@ -87,7 +104,9 @@ class W4PL_Helper_Presets {
 			$options = array();
 		}
 
-		// The starter picker is a one-shot editor action, never stored.
+		// The starter picker is a one-shot editor action, never stored. The
+		// _starter_applied marker is left alone here: it must survive this
+		// filter for the editor view, and the save path strips it.
 		unset( $options['starter_template'] );
 
 		// Quick kill.

--- a/includes/helpers/class-helper-presets.php
+++ b/includes/helpers/class-helper-presets.php
@@ -67,12 +67,15 @@ class W4PL_Helper_Presets {
 			$applied = W4PL_Starter_Templates::get( $options['_starter_applied'] );
 
 			if ( $applied ) {
+				// Rendered inside the Template group (position 152 sits just
+				// after its opener at 150), because the apply flow lands the
+				// user on that tab.
 				$fields['starter_applied_notice'] = array(
-					'position' => '3.05',
+					'position' => '152',
 					'html'     => '<div class="notice notice-success inline w4pl-starter-applied" data-show-tab="w4pl_field_group_template" style="margin:0 0 10px;"><p>'
 						. sprintf(
 							/* translators: %s: starter template label */
-							esc_html__( '"%s" applied — its markup and styles are now in the Template and Style sections, ready to edit.', 'w4-post-list' ),
+							esc_html__( '"%s" applied — this is its markup, and its styles are in the Style section. Edit anything.', 'w4-post-list' ),
 							esc_html( $applied['label'] )
 						)
 						. '</p></div>',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "w4-post-list",
-	"version": "2.9.0",
+	"version": "2.10.0",
 	"description": "A WordPress Plugin for listing posts in some handy manner.",
 	"main": "Gruntfile.js",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "w4-post-list",
-	"version": "2.10.0",
+	"version": "2.11.0",
 	"description": "A WordPress Plugin for listing posts in some handy manner.",
 	"main": "Gruntfile.js",
 	"scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: post list, user list, post grid, category list, shortcode
 Requires at least: 5.8
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 2.9.0
+Stable tag: 2.10.0
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -120,6 +120,9 @@ In your admin: **W4 Post List → Documentation** (template tags reference, exam
 
 
 == Changelog ==
+= 2.10.0 =
+* New: Live preview in the list editor - a Preview button renders your current, unsaved settings in an isolated pane, refreshing automatically after option changes. No more publish-and-reload loops while designing a list.
+* Improved: Getting Started guide mentions the preview workflow.
 = 2.9.0 =
 * New: "Start from a template" - pick from 8 ready-made layouts (simple list, thumbnail cards, title & date list, year archive, category index, category index with posts, user directory, authors with posts). Picking one copies editable markup and styles into the Template and Style fields and sets the options it needs, like Group by. Developers can add layouts via the w4pl/starter_templates filter.
 * Improved: Lists using a legacy preset keep working exactly as before; the legacy preset field only appears on those lists.
@@ -176,6 +179,8 @@ In your admin: **W4 Post List → Documentation** (template tags reference, exam
 [See changelog of all versions](https://raw.githubusercontent.com/w4devInc/w4-post-list/master/CHANGELOG.txt).
 
 == Upgrade Notice ==
+= 2.10.0 =
+Live preview in the list editor.
 = 2.9.0 =
 Eight ready-made starter templates with copy-on-select editing. Legacy presets unchanged.
 = 2.8.0 =

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: post list, user list, post grid, category list, shortcode
 Requires at least: 5.8
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 2.10.0
+Stable tag: 2.11.0
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -120,6 +120,12 @@ In your admin: **W4 Post List → Documentation** (template tags reference, exam
 
 
 == Changelog ==
+= 2.11.0 =
+* New: The editor now catches mistakes at save time - non-numeric values in numeric fields are coerced with a clear warning, unknown template tags get a "did you mean" suggestion, and a template missing its loop tag warns before rendering blank.
+* New: Switching list type with an incompatible template shows an inline warning with a one-click "Replace with the default template" fix.
+* New: The list editor form is protected by a nonce; quick edit, bulk edit and autosave can never touch list options.
+* Improved: "Any" post status now excludes the concrete statuses automatically.
+* New: A once-only review request appears a week after your first published list. One click dismisses it forever.
 = 2.10.0 =
 * New: Live preview in the list editor - a Preview button renders your current, unsaved settings in an isolated pane, refreshing automatically after option changes. No more publish-and-reload loops while designing a list.
 * Improved: Getting Started guide mentions the preview workflow.
@@ -179,6 +185,8 @@ In your admin: **W4 Post List → Documentation** (template tags reference, exam
 [See changelog of all versions](https://raw.githubusercontent.com/w4devInc/w4-post-list/master/CHANGELOG.txt).
 
 == Upgrade Notice ==
+= 2.11.0 =
+Save-time validation with helpful warnings, editor nonce, list-type-switch protection.
 = 2.10.0 =
 Live preview in the list editor.
 = 2.9.0 =

--- a/tests/MANUAL-QA.md
+++ b/tests/MANUAL-QA.md
@@ -28,6 +28,13 @@ in ~5 minutes on the docker dev site.
 - [ ] "Display this list" box appears in the sidebar with the correct `[postlist id="N"]`
 - [ ] Copy button copies; "Copied!" confirmation shows; works on a draft (with publish reminder)
 
+## Live preview
+
+- [ ] Preview button under the editor toggles the pane; first open renders the current (unsaved) settings
+- [ ] Change list type or template, wait for the form refresh: an open preview refreshes itself
+- [ ] Starter template + preview: pick a starter, preview shows the new layout with its CSS
+- [ ] Preview of a list with an error (e.g. temporarily break the template) shows the error message in the status line, not a broken pane
+
 ## Error surfacing
 
 - [ ] `[postlist id="99999"]` on a page: logged-in as editor → inline notice; logged-out → nothing

--- a/tests/MANUAL-QA.md
+++ b/tests/MANUAL-QA.md
@@ -35,6 +35,15 @@ in ~5 minutes on the docker dev site.
 - [ ] Starter template + preview: pick a starter, preview shows the new layout with its CSS
 - [ ] Preview of a list with an error (e.g. temporarily break the template) shows the error message in the status line, not a broken pane
 
+## Validation & review prompt (M8)
+
+- [ ] Save a list with "ten" in Items per page: saves fine, warning notice explains the coercion
+- [ ] Save a template with a typo'd tag ([post_titel]): warning suggests [post_title]
+- [ ] Switch list type with an incompatible template: inline warning appears with a working "Replace with the default template" button (into CodeMirror)
+- [ ] Check "Any" post status: concrete statuses uncheck, and vice versa
+- [ ] Quick-edit a list title: list options survive untouched
+- [ ] (Time-gated) Review prompt appears on the Lists screen 7+ days after first publish; dismiss is permanent
+
 ## Error surfacing
 
 - [ ] `[postlist id="99999"]` on a page: logged-in as editor → inline notice; logged-out → nothing

--- a/tests/PreviewAjaxTest.php
+++ b/tests/PreviewAjaxTest.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Preview endpoint authorization (nonce + capability).
+ *
+ * @package W4_Post_List
+ *
+ * @group ajax
+ */
+
+class PreviewAjaxTest extends WP_Ajax_UnitTestCase {
+
+	protected static $list_id;
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		require_once dirname( __DIR__ ) . '/admin/class-admin-lists-metaboxes.php';
+		require_once dirname( __DIR__ ) . '/admin/class-admin-preview.php';
+
+		self::$list_id = $factory->post->create(
+			array(
+				'post_type'   => 'w4pl',
+				'post_status' => 'publish',
+			)
+		);
+	}
+
+	public function set_up() {
+		parent::set_up();
+
+		// Hooks are restored to the run-global snapshot after every test, so
+		// the ajax action must be registered per-test, after the backup.
+		new W4PL_Admin_Preview();
+	}
+
+	public function test_missing_nonce_is_rejected() {
+		$this->_setRole( 'administrator' );
+		$_POST['w4pl'] = array( 'id' => self::$list_id );
+
+		$this->expectException( 'WPAjaxDieStopException' );
+		$this->_handleAjax( 'w4pl_list_preview' );
+	}
+
+	public function test_insufficient_capability_is_rejected() {
+		$this->_setRole( 'subscriber' );
+		$_POST['nonce'] = wp_create_nonce( 'w4pl_preview' );
+		$_POST['w4pl']  = array(
+			'id'        => self::$list_id,
+			'list_type' => 'posts',
+		);
+
+		try {
+			$this->_handleAjax( 'w4pl_list_preview' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			// Expected: wp_send_json_error ends with die.
+			unset( $e );
+		}
+
+		$response = json_decode( $this->_last_response, true );
+		$this->assertNotNull( $response, 'RAW RESPONSE: ' . substr( $this->_last_response, 0, 400 ) );
+		$this->assertFalse( $response['success'] );
+	}
+
+	public function test_authorized_request_returns_rendered_html() {
+		$this->_setRole( 'administrator' );
+		$_POST['nonce'] = wp_create_nonce( 'w4pl_preview' );
+		$_POST['w4pl']  = array(
+			'id'             => self::$list_id,
+			'list_type'      => 'posts',
+			'post_type'      => array( 'post' ),
+			'posts_per_page' => 5,
+		);
+
+		try {
+			$this->_handleAjax( 'w4pl_list_preview' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			unset( $e );
+		}
+
+		$response = json_decode( $this->_last_response, true );
+		$this->assertNotNull( $response, 'RAW RESPONSE: ' . substr( $this->_last_response, 0, 400 ) );
+		$this->assertTrue( $response['success'] );
+		$this->assertStringContainsString( 'w4pl', $response['data']['html'] );
+	}
+}

--- a/tests/PreviewTest.php
+++ b/tests/PreviewTest.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Live preview rendering and endpoint authorization.
+ *
+ * @package W4_Post_List
+ */
+
+require_once __DIR__ . '/class-w4pl-snapshot-testcase.php';
+
+class PreviewTest extends W4PL_Snapshot_TestCase {
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
+		require_once dirname( __DIR__ ) . '/admin/class-admin-lists-metaboxes.php';
+		require_once dirname( __DIR__ ) . '/admin/class-admin-preview.php';
+	}
+
+	public function test_render_preview_matches_shortcode_output_for_same_options() {
+		$options = array(
+			'id'             => 424242,
+			'list_type'      => 'posts',
+			'post_type'      => array( 'post' ),
+			'posts_per_page' => 10,
+			'orderby'        => 'post_date',
+			'order'          => 'DESC',
+		);
+
+		$preview = W4PL_Admin_Preview::render_preview( $options );
+
+		$this->assertStringContainsString( 'Winter release notes', $preview );
+		$this->assertStringContainsString( 'class="post-item"', $preview, 'Preview uses the default template pipeline' );
+	}
+
+	public function test_render_preview_renders_unsaved_starter_output() {
+		$options = W4PL_Starter_Templates::apply(
+			array(
+				'id'               => 424242,
+				'list_type'        => 'posts',
+				'post_type'        => array( 'post' ),
+				'starter_template' => 'thumbnail-cards',
+			)
+		);
+
+		$preview = W4PL_Admin_Preview::render_preview( $options );
+
+		$this->assertStringContainsString( 'w4pl-cards', $preview );
+	}
+
+	public function test_render_preview_throws_for_invalid_type() {
+		$this->expectException( Exception::class );
+
+		W4PL_Admin_Preview::render_preview(
+			array(
+				'id'        => 424242,
+				'list_type' => 'bogus',
+			)
+		);
+	}
+}

--- a/tests/StarterTemplatesTest.php
+++ b/tests/StarterTemplatesTest.php
@@ -223,8 +223,27 @@ class StarterTemplatesTest extends W4PL_Snapshot_TestCase {
 		);
 
 		$this->assertArrayNotHasKey( 'starter_template', $options );
+		$this->assertArrayNotHasKey( '_starter_applied', $options, 'Editor-only marker must never be persisted' );
 		$this->assertStringContainsString( 'w4pl-simple-list', $options['template'] );
 		$this->assertSame( W4PL_Options_Migrator::OPTIONS_VERSION, $options['options_version'] );
+	}
+
+	public function test_editor_apply_sets_confirmation_marker_and_field_notice() {
+		$editor = new W4PL_List_Editor(
+			array(
+				'id'               => 1,
+				'list_type'        => 'posts',
+				'starter_template' => 'thumbnail-cards',
+			)
+		);
+
+		$this->assertSame( 'thumbnail-cards', $editor->options['_starter_applied'], 'Marker must survive the editor filter chain' );
+
+		$fields = apply_filters( 'w4pl/list_edit_form_fields', array(), $editor->options );
+
+		$this->assertArrayHasKey( 'starter_applied_notice', $fields );
+		$this->assertStringContainsString( 'data-show-tab="w4pl_field_group_template"', $fields['starter_applied_notice']['html'] );
+		$this->assertStringContainsString( 'Thumbnail cards', $fields['starter_applied_notice']['html'] );
 	}
 
 	public function test_editor_applies_starter_before_field_rendering() {

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -1,0 +1,195 @@
+<?php
+/**
+ * Save-time validation, nonce behavior, and the review prompt gate.
+ *
+ * @package W4_Post_List
+ */
+
+class ValidationTest extends WP_UnitTestCase {
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		require_once dirname( __DIR__ ) . '/admin/class-admin-lists-metaboxes.php';
+		require_once dirname( __DIR__ ) . '/admin/class-admin-validation.php';
+		require_once dirname( __DIR__ ) . '/admin/class-admin-onboarding.php';
+	}
+
+	public function set_up() {
+		parent::set_up();
+		new W4PL_Admin_Validation();
+
+		delete_option( 'w4pl_first_publish_time' );
+		delete_option( 'w4pl_review_dismissed' );
+	}
+
+	public function tear_down() {
+		unset( $_POST['w4pl'], $_POST['w4pl_options_nonce'] );
+		parent::tear_down();
+	}
+
+	// ----- Numeric coercion -----
+
+	public function test_coerce_numeric_reads_leading_digits_and_drops_garbage() {
+		$this->assertSame( '10', W4PL_Admin_Validation::coerce_numeric( '10 posts' ) );
+		$this->assertSame( '', W4PL_Admin_Validation::coerce_numeric( 'ten' ) );
+		$this->assertSame( '3', W4PL_Admin_Validation::coerce_numeric( '3' ) );
+	}
+
+	public function test_save_filter_coerces_and_records_warnings() {
+		$options = apply_filters(
+			'w4pl/pre_save_options',
+			array(
+				'id'             => 777,
+				'list_type'      => 'posts',
+				'posts_per_page' => 'ten',
+			)
+		);
+
+		$this->assertSame( '', $options['posts_per_page'] );
+
+		$warnings = get_transient( 'w4pl_save_warnings_777' );
+		$this->assertNotEmpty( $warnings );
+		$this->assertStringContainsString( 'posts_per_page', $warnings[0] );
+	}
+
+	public function test_valid_numeric_values_produce_no_warnings() {
+		apply_filters(
+			'w4pl/pre_save_options',
+			array(
+				'id'             => 778,
+				'list_type'      => 'posts',
+				'posts_per_page' => '12',
+				'template'       => '[posts][post_title][/posts]',
+			)
+		);
+
+		$this->assertFalse( get_transient( 'w4pl_save_warnings_778' ) );
+	}
+
+	// ----- Template scanning -----
+
+	public function test_unknown_tag_warning_includes_suggestion() {
+		$warnings = W4PL_Admin_Validation::template_warnings(
+			array(
+				'list_type' => 'posts',
+				'template'  => '[posts][post_titel][/posts]',
+			)
+		);
+
+		$this->assertCount( 1, $warnings );
+		$this->assertStringContainsString( 'post_titel', $warnings[0] );
+		$this->assertStringContainsString( 'post_title', $warnings[0] );
+	}
+
+	public function test_missing_loop_tag_warning_for_list_type() {
+		$warnings = W4PL_Admin_Validation::template_warnings(
+			array(
+				'list_type' => 'terms',
+				'template'  => '[posts][post_title][/posts]',
+			)
+		);
+
+		$found = false;
+		foreach ( $warnings as $warning ) {
+			if ( false !== strpos( $warning, '[terms]' ) ) {
+				$found = true;
+			}
+		}
+		$this->assertTrue( $found, 'Missing-loop warning expected for terms list with posts-only template' );
+	}
+
+	public function test_clean_template_produces_no_warnings() {
+		$warnings = W4PL_Admin_Validation::template_warnings(
+			array(
+				'list_type' => 'posts',
+				'template'  => "[posts]\n<div class=\"post-item\">[post_title]</div>\n[/posts]\n[nav]",
+			)
+		);
+
+		$this->assertSame( array(), $warnings );
+	}
+
+	// ----- Save-path nonce -----
+
+	protected function make_list_with_options() {
+		$id = self::factory()->post->create( array( 'post_type' => 'w4pl' ) );
+		update_post_meta( $id, '_w4pl', array( 'list_type' => 'posts', 'posts_per_page' => 5 ) );
+		return $id;
+	}
+
+	public function test_save_without_posted_options_leaves_meta_untouched() {
+		$id = $this->make_list_with_options();
+
+		$metaboxes = new W4PL_Admin_Lists_Metaboxes();
+		$metaboxes->save_post( $id );
+
+		$this->assertSame( 5, get_post_meta( $id, '_w4pl', true )['posts_per_page'], 'Quick-edit style save must not wipe options' );
+	}
+
+	public function test_save_with_options_but_bad_nonce_bails_without_wiping() {
+		$id = $this->make_list_with_options();
+
+		$_POST['w4pl']               = array( 'list_type' => 'terms' );
+		$_POST['w4pl_options_nonce'] = 'not-a-nonce';
+
+		$metaboxes = new W4PL_Admin_Lists_Metaboxes();
+		$metaboxes->save_post( $id );
+
+		$stored = get_post_meta( $id, '_w4pl', true );
+		$this->assertSame( 'posts', $stored['list_type'], 'Invalid nonce must bail, not wipe or apply' );
+	}
+
+	public function test_save_with_valid_nonce_persists_options() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		$id = $this->make_list_with_options();
+
+		$_POST['w4pl']               = array(
+			'list_type'      => 'posts',
+			'posts_per_page' => '7',
+		);
+		$_POST['w4pl_options_nonce'] = wp_create_nonce( 'w4pl_save_options' );
+
+		$metaboxes = new W4PL_Admin_Lists_Metaboxes();
+		$metaboxes->save_post( $id );
+
+		$stored = get_post_meta( $id, '_w4pl', true );
+		$this->assertSame( '7', $stored['posts_per_page'] );
+		$this->assertSame( W4PL_Options_Migrator::OPTIONS_VERSION, $stored['options_version'] );
+	}
+
+	// ----- Review prompt gate -----
+
+	public function test_review_prompt_waits_for_first_publish_plus_seven_days() {
+		$this->assertFalse( W4PL_Admin_Onboarding::review_prompt_due(), 'No publish yet' );
+
+		update_option( 'w4pl_first_publish_time', time() - DAY_IN_SECONDS );
+		$this->assertFalse( W4PL_Admin_Onboarding::review_prompt_due(), 'Too recent' );
+
+		update_option( 'w4pl_first_publish_time', time() - 8 * DAY_IN_SECONDS );
+		$this->assertTrue( W4PL_Admin_Onboarding::review_prompt_due() );
+
+		update_option( 'w4pl_review_dismissed', time() );
+		$this->assertFalse( W4PL_Admin_Onboarding::review_prompt_due(), 'Dismissal is permanent' );
+	}
+
+	public function test_first_publish_time_is_recorded_once() {
+		self::factory()->post->create(
+			array(
+				'post_type'   => 'w4pl',
+				'post_status' => 'publish',
+			)
+		);
+
+		$first = get_option( 'w4pl_first_publish_time' );
+		$this->assertNotEmpty( $first );
+
+		self::factory()->post->create(
+			array(
+				'post_type'   => 'w4pl',
+				'post_status' => 'publish',
+			)
+		);
+
+		$this->assertSame( $first, get_option( 'w4pl_first_publish_time' ), 'First-publish time never moves' );
+	}
+}

--- a/tests/class-w4pl-snapshot-testcase.php
+++ b/tests/class-w4pl-snapshot-testcase.php
@@ -97,6 +97,7 @@ abstract class W4PL_Snapshot_TestCase extends WP_UnitTestCase {
 	protected function normalize( $html ) {
 		$patterns = array(
 			'/W4PL_List_\d+/'                 => 'W4PL_List_{ID}',
+			'/W4PL_List \d+/'                 => 'W4PL_List {ID}',
 			'/w4pl-list-\d+/'                 => 'w4pl-list-{ID}',
 			'/w4pl-inner-\d+/'                => 'w4pl-inner-{ID}',
 			'/w4pl-css-\d+/'                  => 'w4pl-css-{ID}',

--- a/tests/snapshots/starter-category-index.html
+++ b/tests/snapshots/starter-category-index.html
@@ -1,4 +1,4 @@
-<!--W4PL_List 39-->
+<!--W4PL_List {ID}-->
 <style id="w4pl-css-{ID}" type="text/css">#w4pl-list-{ID} .w4pl-category-index {
 	list-style: none;
 	margin: 0;
@@ -50,4 +50,4 @@
 </ul>
 	</div><!--#w4pl-inner-{ID}-->
 </div><!--#w4pl-{ID}-->
-<!--end W4PL_List 39-->
+<!--end W4PL_List {ID}-->

--- a/tests/snapshots/terms-default.html
+++ b/tests/snapshots/terms-default.html
@@ -1,4 +1,4 @@
-<!--W4PL_List 14-->
+<!--W4PL_List {ID}-->
 <div id="w4pl-list-{ID}" class="w4pl">
 	<div id="w4pl-inner-{ID}" class="w4pl-inner">
 		<div class="term-item">
@@ -20,4 +20,4 @@
 	</div>
 	</div><!--#w4pl-inner-{ID}-->
 </div><!--#w4pl-{ID}-->
-<!--end W4PL_List 14-->
+<!--end W4PL_List {ID}-->

--- a/w4-post-list.php
+++ b/w4-post-list.php
@@ -3,7 +3,7 @@
  * Plugin Name: W4 Post List
  * Plugin URI: https://w4dev.com/plugins/w4-post-list
  * Description: Create lists of posts, terms and users — grouped archives, taxonomy indexes and user directories — placed anywhere with the block, [postlist] shortcode or widget.
- * Version: 2.10.0
+ * Version: 2.11.0
  * Requires at least: 5.8
  * Requires PHP: 7.4
  * Author: Shazzad Hossain Khan

--- a/w4-post-list.php
+++ b/w4-post-list.php
@@ -3,7 +3,7 @@
  * Plugin Name: W4 Post List
  * Plugin URI: https://w4dev.com/plugins/w4-post-list
  * Description: Create lists of posts, terms and users — grouped archives, taxonomy indexes and user directories — placed anywhere with the block, [postlist] shortcode or widget.
- * Version: 2.9.0
+ * Version: 2.10.0
  * Requires at least: 5.8
  * Requires PHP: 7.4
  * Author: Shazzad Hossain Khan


### PR DESCRIPTION
## Summary

**Stacked on #114 (M7) → #113 (M6)** — merge order: #113, #114, then this.

- **Mistakes are caught at save time, never rejected**: non-numeric values in numeric fields coerce with a clear warning notice after redirect ("ten" → empty, "10 posts" → 10); unknown template tags warn with a levenshtein **did-you-mean** ([post_titel] → [post_title]); a template missing its list type's loop tag warns before it renders blank. Existing stored lists keep rendering identically (snapshot suite untouched).
- **The editor form finally has a nonce** — with the quick-edit trap from the roadmap explicitly avoided: the nonce is verified *only when list options are posted*, and an invalid nonce bails without wiping. Tests prove quick-edit/bulk-edit/autosave-style saves leave options untouched.
- **The list-type-switch trap is closed**: an incompatible template shows an inline warning in the Template section (server-rendered, so it appears right after the AJAX type switch) with a one-click "Replace with the default template" button that writes through CodeMirror.
- **"Any" post status is now exclusive** of concrete statuses (the meaningless "Any + Draft" combination can't be expressed).
- **Review request**: once-only, on the Lists screen, 7+ days after the first published list (tracked via `w4pl_first_publish_time`), permanent nonce-checked dismissal — starts rebuilding wp.org social proof per the roadmap's growth thesis.

## Test plan
- [x] 82 tests / 342 assertions green (11 new: coercion, warning transients, tag suggestions, loop-tag warnings, all three nonce paths incl. no-wipe guarantees, review-prompt gate, first-publish recording)
- [x] JS syntax validated; MANUAL-QA.md extended with an M8 section
- [ ] CI green on PHP 7.4 + 8.2

Do not merge — awaiting maintainer review per instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)