### PR TITLE
v2.10.0: Live preview in the list editor (M7) [remerge of #114]

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,7 @@
 == Changelog ==
+= 2.10.0 =
+* New: Live preview in the list editor - a Preview button renders your current, unsaved settings in an isolated pane, refreshing automatically after option changes. No more publish-and-reload loops while designing a list.
+* Improved: Getting Started guide mentions the preview workflow.
 = 2.9.0 =
 * New: "Start from a template" - pick from 8 ready-made layouts (simple list, thumbnail cards, title & date list, year archive, category index, category index with posts, user directory, authors with posts). Picking one copies editable markup and styles into the Template and Style fields and sets the options it needs, like Group by. Developers can add layouts via the w4pl/starter_templates filter.
 * Improved: Lists using a legacy preset keep working exactly as before; the legacy preset field only appears on those lists.

--- a/admin/class-admin-list-editor.php
+++ b/admin/class-admin-list-editor.php
@@ -62,7 +62,12 @@ class W4PL_List_Editor {
 			'w4pl_list_editor',
 			'w4plListEditor',
 			array(
-				'refreshFailed' => __( 'Could not refresh the form. Your entries are unchanged — check your connection and try again.', 'w4-post-list' ),
+				'refreshFailed'  => __( 'Could not refresh the form. Your entries are unchanged — check your connection and try again.', 'w4-post-list' ),
+				'previewNonce'   => wp_create_nonce( 'w4pl_preview' ),
+				'previewLoading' => __( 'Rendering preview…', 'w4-post-list' ),
+				'previewFailed'  => __( 'Preview failed — check your connection and try again.', 'w4-post-list' ),
+				'previewHide'    => __( 'Hide preview', 'w4-post-list' ),
+				'previewShow'    => __( 'Preview', 'w4-post-list' ),
 			)
 		);
 		wp_enqueue_style( 'w4pl_form' );

--- a/admin/class-admin-lists-metaboxes.php
+++ b/admin/class-admin-lists-metaboxes.php
@@ -188,7 +188,7 @@ class W4PL_Admin_Lists_Metaboxes {
 	 * @param array $options List options.
 	 * @return array
 	 */
-	public function sanitize_options( $options ) {
+	public static function sanitize_options( $options ) {
 		// Sanitize options.
 		foreach ( array( 'no_items_text' ) as $key ) {
 			if ( array_key_exists( $key, $options ) ) {

--- a/admin/class-admin-preview.php
+++ b/admin/class-admin-preview.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Live preview of unsaved list options in the editor.
+ *
+ * @class W4PL_Admin_Preview
+ * @package W4_Post_List
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Renders the current (possibly unsaved) editor options to HTML on demand.
+ */
+class W4PL_Admin_Preview {
+
+	/**
+	 * Constructor
+	 */
+	public function __construct() {
+		add_action( 'wp_ajax_w4pl_list_preview', array( $this, 'ajax_preview' ) );
+		add_action( 'edit_form_after_title', array( $this, 'preview_pane' ), 30 );
+	}
+
+	/**
+	 * Render posted options through the exact pipeline the shortcode uses.
+	 *
+	 * @param  array $options Raw (unslashed) options from the editor form.
+	 * @return string
+	 * @throws Exception When the options cannot produce a list.
+	 */
+	public static function render_preview( array $options ) {
+		$options = W4PL_Admin_Lists_Metaboxes::sanitize_options( $options );
+		$options = apply_filters( 'w4pl/pre_get_options', $options );
+
+		$list = W4PL_List_Factory::get_list( $options );
+
+		return $list->get_html();
+	}
+
+	/**
+	 * AJAX endpoint: nonce + per-post capability checked.
+	 */
+	public function ajax_preview() {
+		check_ajax_referer( 'w4pl_preview', 'nonce' );
+
+		$posted = array();
+		if ( isset( $_POST['w4pl'] ) && is_array( $_POST['w4pl'] ) ) {
+			// Sanitized field-by-field in render_preview() via sanitize_options().
+			$posted = wp_unslash( $_POST['w4pl'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		}
+
+		$list_id = 0;
+		if ( isset( $posted['id'] ) ) {
+			$list_id = (int) $posted['id'];
+		}
+
+		if ( ! $list_id || ! current_user_can( 'edit_post', $list_id ) ) {
+			wp_send_json_error(
+				array( 'message' => __( 'You do not have permission to preview this list.', 'w4-post-list' ) ),
+				403
+			);
+		}
+
+		// Only the render is guarded; the send calls stay outside so their
+		// terminating behavior is never swallowed by this catch.
+		try {
+			$html = self::render_preview( $posted );
+		} catch ( Exception $e ) {
+			wp_send_json_error( array( 'message' => $e->getMessage() ) );
+		}
+
+		wp_send_json_success( array( 'html' => $html ) );
+	}
+
+	/**
+	 * Preview region under the editor form. Lives outside #w4pl_list_options
+	 * so it survives the AJAX form replacement.
+	 *
+	 * @param WP_Post $post Current post.
+	 */
+	public function preview_pane( $post ) {
+		if ( ! $post instanceof WP_Post || W4PL_Config::LIST_POST_TYPE !== $post->post_type ) {
+			return;
+		}
+		?>
+		<div id="w4pl_preview_wrap" style="margin-top:12px;">
+			<p style="margin:0 0 8px;">
+				<button type="button" class="button" id="w4pl_preview_toggle" aria-expanded="false" aria-controls="w4pl_preview_pane">
+					<?php esc_html_e( 'Preview', 'w4-post-list' ); ?>
+				</button>
+				<span id="w4pl_preview_status" role="status" style="margin-left:8px;color:#777;"></span>
+			</p>
+			<div id="w4pl_preview_pane" style="display:none;border:1px solid #dcdcde;border-radius:4px;background:#fff;">
+				<iframe id="w4pl_preview_frame" title="<?php esc_attr_e( 'List preview', 'w4-post-list' ); ?>" style="width:100%;height:420px;border:0;"></iframe>
+			</div>
+			<p class="description" style="margin-top:6px;">
+				<?php esc_html_e( 'The preview renders your unsaved settings without your theme\'s styles, so spacing and fonts will differ on the real page.', 'w4-post-list' ); ?>
+			</p>
+		</div>
+		<?php
+	}
+}

--- a/admin/pages/views/html-getting-started.php
+++ b/admin/pages/views/html-getting-started.php
@@ -38,6 +38,7 @@
 	</h3>
 	<p>
 		<?php esc_html_e( 'A default template is applied automatically, so you do not need to touch the Template section to get output. Click Publish.', 'w4-post-list' ); ?>
+		<?php esc_html_e( 'Use the Preview button under the editor at any time to see the rendered list without saving.', 'w4-post-list' ); ?>
 	</p>
 
 	<h3>

--- a/assets/js/list-editor.js
+++ b/assets/js/list-editor.js
@@ -226,6 +226,65 @@
 		});
 	}
 
+	/* ----- Live preview ----- */
+
+	function w4pl_l10n(key, fallback) {
+		if (window.w4plListEditor && window.w4plListEditor[key]) {
+			return window.w4plListEditor[key];
+		}
+		return fallback;
+	}
+
+	function w4pl_refresh_preview() {
+		var pane = $('#w4pl_preview_pane');
+		var status = $('#w4pl_preview_status');
+
+		if (!pane.length || !pane.is(':visible')) {
+			return;
+		}
+
+		w4pl_sync_code_editors();
+		status.text(w4pl_l10n('previewLoading', 'Rendering preview…'));
+
+		var data = $('#w4pl_list_options :input').serialize()
+			+ '&action=w4pl_list_preview'
+			+ '&nonce=' + encodeURIComponent(w4pl_l10n('previewNonce', ''));
+
+		$.post(ajaxurl, data, function (r) {
+			if (r && r.success && r.data && typeof r.data.html === 'string') {
+				var frame = document.getElementById('w4pl_preview_frame');
+				frame.srcdoc = '<!doctype html><html><head><meta charset="utf-8">'
+					+ '<style>body{margin:16px;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;color:#1e1e1e;}img{max-width:100%;height:auto;}</style>'
+					+ '</head><body>' + r.data.html + '</body></html>';
+				status.text('');
+			} else {
+				status.text((r && r.data && r.data.message) ? r.data.message : w4pl_l10n('previewFailed', 'Preview failed.'));
+			}
+		}).fail(function () {
+			status.text(w4pl_l10n('previewFailed', 'Preview failed — check your connection and try again.'));
+		});
+	}
+
+	$(document.body).on('click', '#w4pl_preview_toggle', function () {
+		var pane = $('#w4pl_preview_pane');
+		var open = pane.is(':visible');
+
+		if (open) {
+			pane.hide();
+			$(this).attr('aria-expanded', 'false').text(w4pl_l10n('previewShow', 'Preview'));
+		} else {
+			pane.show();
+			$(this).attr('aria-expanded', 'true').text(w4pl_l10n('previewHide', 'Hide preview'));
+			w4pl_refresh_preview();
+		}
+		return false;
+	});
+
+	/* Keep an open preview in sync after each successful form refresh. */
+	$(document).on('w4pl/form_loaded', function () {
+		w4pl_refresh_preview();
+	});
+
 	/*
 	 * Insert a template tag at the cursor - into the CodeMirror instance when
 	 * one owns the field, or the plain textarea otherwise.

--- a/includes/class-w4-post-list.php
+++ b/includes/class-w4-post-list.php
@@ -29,7 +29,7 @@ final class W4_Post_List {
 	 *
 	 * @var string
 	 */
-	public $version = '2.9.0';
+	public $version = '2.10.0';
 
 	/**
 	 * This will hold current class instance
@@ -131,6 +131,7 @@ final class W4_Post_List {
 			include W4PL_DIR . '/admin/class-admin-lists-metaboxes.php';
 			include W4PL_DIR . '/admin/class-admin-list-editor.php';
 			include W4PL_DIR . '/admin/class-admin-onboarding.php';
+			include W4PL_DIR . '/admin/class-admin-preview.php';
 
 			/* Admin pages */
 			foreach ( glob( W4PL_DIR . 'admin/pages/*.php' ) as $file ) {
@@ -173,6 +174,7 @@ final class W4_Post_List {
 			new W4PL_Admin_Lists_Table_Columns();
 			new W4PL_Admin_Lists_Metaboxes();
 			new W4PL_Admin_Onboarding();
+			new W4PL_Admin_Preview();
 
 			new W4PL_Admin_Page_Docs();
 		}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "w4-post-list",
-	"version": "2.9.0",
+	"version": "2.10.0",
 	"description": "A WordPress Plugin for listing posts in some handy manner.",
 	"main": "Gruntfile.js",
 	"scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: post list, user list, post grid, category list, shortcode
 Requires at least: 5.8
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 2.9.0
+Stable tag: 2.10.0
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -120,6 +120,9 @@ In your admin: **W4 Post List → Documentation** (template tags reference, exam
 
 
 == Changelog ==
+= 2.10.0 =
+* New: Live preview in the list editor - a Preview button renders your current, unsaved settings in an isolated pane, refreshing automatically after option changes. No more publish-and-reload loops while designing a list.
+* Improved: Getting Started guide mentions the preview workflow.
 = 2.9.0 =
 * New: "Start from a template" - pick from 8 ready-made layouts (simple list, thumbnail cards, title & date list, year archive, category index, category index with posts, user directory, authors with posts). Picking one copies editable markup and styles into the Template and Style fields and sets the options it needs, like Group by. Developers can add layouts via the w4pl/starter_templates filter.
 * Improved: Lists using a legacy preset keep working exactly as before; the legacy preset field only appears on those lists.
@@ -176,6 +179,8 @@ In your admin: **W4 Post List → Documentation** (template tags reference, exam
 [See changelog of all versions](https://raw.githubusercontent.com/w4devInc/w4-post-list/master/CHANGELOG.txt).
 
 == Upgrade Notice ==
+= 2.10.0 =
+Live preview in the list editor.
 = 2.9.0 =
 Eight ready-made starter templates with copy-on-select editing. Legacy presets unchanged.
 = 2.8.0 =

--- a/tests/MANUAL-QA.md
+++ b/tests/MANUAL-QA.md
@@ -28,6 +28,13 @@ in ~5 minutes on the docker dev site.
 - [ ] "Display this list" box appears in the sidebar with the correct `[postlist id="N"]`
 - [ ] Copy button copies; "Copied!" confirmation shows; works on a draft (with publish reminder)
 
+## Live preview
+
+- [ ] Preview button under the editor toggles the pane; first open renders the current (unsaved) settings
+- [ ] Change list type or template, wait for the form refresh: an open preview refreshes itself
+- [ ] Starter template + preview: pick a starter, preview shows the new layout with its CSS
+- [ ] Preview of a list with an error (e.g. temporarily break the template) shows the error message in the status line, not a broken pane
+
 ## Error surfacing
 
 - [ ] `[postlist id="99999"]` on a page: logged-in as editor → inline notice; logged-out → nothing

--- a/tests/PreviewAjaxTest.php
+++ b/tests/PreviewAjaxTest.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Preview endpoint authorization (nonce + capability).
+ *
+ * @package W4_Post_List
+ *
+ * @group ajax
+ */
+
+class PreviewAjaxTest extends WP_Ajax_UnitTestCase {
+
+	protected static $list_id;
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		require_once dirname( __DIR__ ) . '/admin/class-admin-lists-metaboxes.php';
+		require_once dirname( __DIR__ ) . '/admin/class-admin-preview.php';
+
+		self::$list_id = $factory->post->create(
+			array(
+				'post_type'   => 'w4pl',
+				'post_status' => 'publish',
+			)
+		);
+	}
+
+	public function set_up() {
+		parent::set_up();
+
+		// Hooks are restored to the run-global snapshot after every test, so
+		// the ajax action must be registered per-test, after the backup.
+		new W4PL_Admin_Preview();
+	}
+
+	public function test_missing_nonce_is_rejected() {
+		$this->_setRole( 'administrator' );
+		$_POST['w4pl'] = array( 'id' => self::$list_id );
+
+		$this->expectException( 'WPAjaxDieStopException' );
+		$this->_handleAjax( 'w4pl_list_preview' );
+	}
+
+	public function test_insufficient_capability_is_rejected() {
+		$this->_setRole( 'subscriber' );
+		$_POST['nonce'] = wp_create_nonce( 'w4pl_preview' );
+		$_POST['w4pl']  = array(
+			'id'        => self::$list_id,
+			'list_type' => 'posts',
+		);
+
+		try {
+			$this->_handleAjax( 'w4pl_list_preview' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			// Expected: wp_send_json_error ends with die.
+			unset( $e );
+		}
+
+		$response = json_decode( $this->_last_response, true );
+		$this->assertNotNull( $response, 'RAW RESPONSE: ' . substr( $this->_last_response, 0, 400 ) );
+		$this->assertFalse( $response['success'] );
+	}
+
+	public function test_authorized_request_returns_rendered_html() {
+		$this->_setRole( 'administrator' );
+		$_POST['nonce'] = wp_create_nonce( 'w4pl_preview' );
+		$_POST['w4pl']  = array(
+			'id'             => self::$list_id,
+			'list_type'      => 'posts',
+			'post_type'      => array( 'post' ),
+			'posts_per_page' => 5,
+		);
+
+		try {
+			$this->_handleAjax( 'w4pl_list_preview' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			unset( $e );
+		}
+
+		$response = json_decode( $this->_last_response, true );
+		$this->assertNotNull( $response, 'RAW RESPONSE: ' . substr( $this->_last_response, 0, 400 ) );
+		$this->assertTrue( $response['success'] );
+		$this->assertStringContainsString( 'w4pl', $response['data']['html'] );
+	}
+}

--- a/tests/PreviewTest.php
+++ b/tests/PreviewTest.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Live preview rendering and endpoint authorization.
+ *
+ * @package W4_Post_List
+ */
+
+require_once __DIR__ . '/class-w4pl-snapshot-testcase.php';
+
+class PreviewTest extends W4PL_Snapshot_TestCase {
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
+		require_once dirname( __DIR__ ) . '/admin/class-admin-lists-metaboxes.php';
+		require_once dirname( __DIR__ ) . '/admin/class-admin-preview.php';
+	}
+
+	public function test_render_preview_matches_shortcode_output_for_same_options() {
+		$options = array(
+			'id'             => 424242,
+			'list_type'      => 'posts',
+			'post_type'      => array( 'post' ),
+			'posts_per_page' => 10,
+			'orderby'        => 'post_date',
+			'order'          => 'DESC',
+		);
+
+		$preview = W4PL_Admin_Preview::render_preview( $options );
+
+		$this->assertStringContainsString( 'Winter release notes', $preview );
+		$this->assertStringContainsString( 'class="post-item"', $preview, 'Preview uses the default template pipeline' );
+	}
+
+	public function test_render_preview_renders_unsaved_starter_output() {
+		$options = W4PL_Starter_Templates::apply(
+			array(
+				'id'               => 424242,
+				'list_type'        => 'posts',
+				'post_type'        => array( 'post' ),
+				'starter_template' => 'thumbnail-cards',
+			)
+		);
+
+		$preview = W4PL_Admin_Preview::render_preview( $options );
+
+		$this->assertStringContainsString( 'w4pl-cards', $preview );
+	}
+
+	public function test_render_preview_throws_for_invalid_type() {
+		$this->expectException( Exception::class );
+
+		W4PL_Admin_Preview::render_preview(
+			array(
+				'id'        => 424242,
+				'list_type' => 'bogus',
+			)
+		);
+	}
+}

--- a/tests/class-w4pl-snapshot-testcase.php
+++ b/tests/class-w4pl-snapshot-testcase.php
@@ -97,6 +97,7 @@ abstract class W4PL_Snapshot_TestCase extends WP_UnitTestCase {
 	protected function normalize( $html ) {
 		$patterns = array(
 			'/W4PL_List_\d+/'                 => 'W4PL_List_{ID}',
+			'/W4PL_List \d+/'                 => 'W4PL_List {ID}',
 			'/w4pl-list-\d+/'                 => 'w4pl-list-{ID}',
 			'/w4pl-inner-\d+/'                => 'w4pl-inner-{ID}',
 			'/w4pl-css-\d+/'                  => 'w4pl-css-{ID}',

--- a/tests/snapshots/starter-category-index.html
+++ b/tests/snapshots/starter-category-index.html
@@ -1,4 +1,4 @@
-<!--W4PL_List 39-->
+<!--W4PL_List {ID}-->
 <style id="w4pl-css-{ID}" type="text/css">#w4pl-list-{ID} .w4pl-category-index {
 	list-style: none;
 	margin: 0;
@@ -50,4 +50,4 @@
 </ul>
 	</div><!--#w4pl-inner-{ID}-->
 </div><!--#w4pl-{ID}-->
-<!--end W4PL_List 39-->
+<!--end W4PL_List {ID}-->

--- a/tests/snapshots/terms-default.html
+++ b/tests/snapshots/terms-default.html
@@ -1,4 +1,4 @@
-<!--W4PL_List 14-->
+<!--W4PL_List {ID}-->
 <div id="w4pl-list-{ID}" class="w4pl">
 	<div id="w4pl-inner-{ID}" class="w4pl-inner">
 		<div class="term-item">
@@ -20,4 +20,4 @@
 	</div>
 	</div><!--#w4pl-inner-{ID}-->
 </div><!--#w4pl-{ID}-->
-<!--end W4PL_List 14-->
+<!--end W4PL_List {ID}-->

--- a/w4-post-list.php
+++ b/w4-post-list.php
@@ -3,7 +3,7 @@
  * Plugin Name: W4 Post List
  * Plugin URI: https://w4dev.com/plugins/w4-post-list
  * Description: Create lists of posts, terms and users — grouped archives, taxonomy indexes and user directories — placed anywhere with the block, [postlist] shortcode or widget.
- * Version: 2.9.0
+ * Version: 2.10.0
  * Requires at least: 5.8
  * Requires PHP: 7.4
  * Author: Shazzad Hossain Khan


### PR DESCRIPTION
Replacement for #114, which GitHub auto-closed (not merged) when its base branch was deleted during the stacked-merge sequence. Identical content — see #114 for the full description and review trail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)