### PR TITLE
Review CTA also dismisses the review ask

### DIFF
--- a/admin/class-admin-onboarding.php
+++ b/admin/class-admin-onboarding.php
@@ -22,6 +22,7 @@ class W4PL_Admin_Onboarding {
 		add_action( 'admin_init', array( $this, 'maybe_create_sample_list' ) );
 		add_action( 'admin_init', array( $this, 'maybe_dismiss_welcome' ) );
 		add_action( 'admin_init', array( $this, 'maybe_dismiss_review_prompt' ) );
+		add_action( 'admin_init', array( $this, 'maybe_go_to_review' ) );
 		add_action( 'admin_notices', array( $this, 'welcome_notice' ) );
 		add_action( 'admin_notices', array( $this, 'empty_state' ) );
 		add_action( 'admin_notices', array( $this, 'review_prompt' ) );
@@ -59,17 +60,57 @@ class W4PL_Admin_Onboarding {
 		}
 
 		$dismiss_url = wp_nonce_url( add_query_arg( 'w4pl_dismiss_review', '1' ), 'w4pl_dismiss_review' );
+		$review_url  = wp_nonce_url( add_query_arg( 'w4pl_review_go', '1' ), 'w4pl_review_go' );
 		?>
-		<div class="notice notice-info">
+		<div class="notice notice-info" id="w4pl_review_notice">
 			<p>
 				<?php esc_html_e( 'You have been building lists with W4 Post List for a while — a short review on wordpress.org helps other people find the plugin, and helps us keep improving it.', 'w4-post-list' ); ?>
 			</p>
 			<p>
-				<a class="button button-primary" href="https://wordpress.org/support/plugin/w4-post-list/reviews/#new-post" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Leave a review', 'w4-post-list' ); ?></a>
+				<a class="button button-primary" href="<?php echo esc_url( $review_url ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Leave a review', 'w4-post-list' ); ?></a>
 				<a class="button" href="<?php echo esc_url( $dismiss_url ); ?>"><?php esc_html_e( 'No thanks / already did', 'w4-post-list' ); ?></a>
 			</p>
 		</div>
+		<script>
+		( function () {
+			var notice = document.getElementById( 'w4pl_review_notice' );
+			if ( ! notice ) {
+				return;
+			}
+			// Either action resolves the ask; hide immediately in this tab.
+			notice.addEventListener( 'click', function ( e ) {
+				if ( e.target.closest && e.target.closest( 'a.button' ) ) {
+					notice.style.display = 'none';
+				}
+			} );
+		} )();
+		</script>
 		<?php
+	}
+
+	/**
+	 * "Leave a review" clicked: mark the ask resolved, then send the (new)
+	 * tab on to the wordpress.org review form. Clicking the ask counts as
+	 * answering it — the notice never shows again either way.
+	 */
+	public function maybe_go_to_review() {
+		if ( ! isset( $_GET['w4pl_review_go'] ) ) {
+			return;
+		}
+
+		if ( ! isset( $_GET['_wpnonce'] ) || ! wp_verify_nonce( sanitize_key( wp_unslash( $_GET['_wpnonce'] ) ), 'w4pl_review_go' ) ) {
+			return;
+		}
+
+		if ( ! current_user_can( 'edit_pages' ) ) {
+			return;
+		}
+
+		update_option( 'w4pl_review_dismissed', time(), false );
+
+		// External fixed destination; wp_safe_redirect would reject the host.
+		wp_redirect( 'https://wordpress.org/support/plugin/w4-post-list/reviews/#new-post' ); // phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect
+		exit;
 	}
 
 	/**

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -17,6 +17,11 @@ class ValidationTest extends WP_UnitTestCase {
 		parent::set_up();
 		new W4PL_Admin_Validation();
 
+		if ( ! function_exists( 'set_current_screen' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/class-wp-screen.php';
+			require_once ABSPATH . 'wp-admin/includes/screen.php';
+		}
+
 		delete_option( 'w4pl_first_publish_time' );
 		delete_option( 'w4pl_review_dismissed' );
 	}
@@ -158,6 +163,21 @@ class ValidationTest extends WP_UnitTestCase {
 	}
 
 	// ----- Review prompt gate -----
+
+	public function test_review_cta_markup_carries_the_resolving_link() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		update_option( 'w4pl_first_publish_time', time() - 8 * DAY_IN_SECONDS );
+		set_current_screen( 'edit-w4pl' );
+
+		$onboarding = new W4PL_Admin_Onboarding();
+
+		ob_start();
+		$onboarding->review_prompt();
+		$html = ob_get_clean();
+
+		$this->assertStringContainsString( 'w4pl_review_go', $html, 'Review CTA must route through the dismissing redirect' );
+		$this->assertStringContainsString( 'w4pl_dismiss_review', $html );
+	}
 
 	public function test_review_prompt_waits_for_first_publish_plus_seven_days() {
 		$this->assertFalse( W4PL_Admin_Onboarding::review_prompt_due(), 'No publish yet' );


### PR DESCRIPTION
## Summary
- "Leave a review" now routes through a nonce-checked admin redirect that records the permanent dismissal *before* forwarding the (new) tab to the wp.org review form — clicking the ask counts as answering it, matching the polite convention. The notice also hides instantly in the current tab.
- "No thanks / already did" unchanged.

## Test plan
- [x] 84 tests / 351 assertions green (new: CTA markup routes through the resolving link)
- [ ] CI green
- [ ] Manual: force the prompt (`wp option update w4pl_first_publish_time <8-days-ago>`), click "Leave a review" → new tab lands on the wp.org review form, notice gone in both tabs and on reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)