### PR TITLE
Finalize changelog and readme for 2.11.0

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,12 +4,13 @@
 * New: Switching list type with an incompatible template shows an inline warning with a one-click "Replace with the default template" fix.
 * New: The list editor form is protected by a nonce; quick edit, bulk edit and autosave can never touch list options.
 * Improved: "Any" post status now excludes the concrete statuses automatically.
-* New: A once-only review request appears a week after your first published list. One click dismisses it forever.
+* New: A once-only review request appears a week after your first published list. Clicking either button - including "Leave a review" itself - resolves it forever.
 = 2.10.0 =
 * New: Live preview in the list editor - a Preview button renders your current, unsaved settings in an isolated pane, refreshing automatically after option changes. No more publish-and-reload loops while designing a list.
 * Improved: Getting Started guide mentions the preview workflow.
 = 2.9.0 =
 * New: "Start from a template" - pick from 8 ready-made layouts (simple list, thumbnail cards, title & date list, year archive, category index, category index with posts, user directory, authors with posts). Picking one copies editable markup and styles into the Template and Style fields and sets the options it needs, like Group by. Developers can add layouts via the w4pl/starter_templates filter.
+* New: Applying a starter shows a confirmation and opens the Template section automatically, so you immediately see what you got.
 * Improved: Lists using a legacy preset keep working exactly as before; the legacy preset field only appears on those lists.
 * Improved: In-plugin docs updated for the new flow; new FAQ "Do I have to write the template myself?".
 * Fix: Guarded the editor form action URL against missing server variables (CLI contexts).

--- a/readme.txt
+++ b/readme.txt
@@ -58,7 +58,7 @@ Place any list anywhere with the **W4 Post List block**, the `[postlist id="123"
 
 = Full control over the output =
 
-Output is template-driven: every list has an HTML template with template tags like `[post_title]`, `[post_permalink]`, `[featured_image]`, `[post_author_name]` and `[post_meta key="..."]`. Start from a ready-made template — cards, archives, category indexes, user directories — and tweak it, or write your own markup for pixel-perfect control. If you want a drag-and-drop visual builder, this plugin isn't that — it keeps you close to your own HTML, which is exactly why themes and developers like it.
+Output is template-driven: every list has an HTML template with template tags like `[post_title]`, `[post_permalink]`, `[featured_image]`, `[post_author_name]` and `[post_meta key="..."]`. Start from a ready-made template — cards, archives, category indexes, user directories — and tweak it, or write your own markup for pixel-perfect control. A live preview in the editor shows your changes before you save. If you want a drag-and-drop visual builder, this plugin isn't that — it keeps you close to your own HTML, which is exactly why themes and developers like it.
 
 See the [full template tag reference](https://w4dev.com/docs/w4-post-list/faqs/what-are-the-available-template-tags/) and [live examples with copy-paste templates](https://w4dev.com/wp/w4-post-list-examples/).
 
@@ -91,6 +91,10 @@ The usual causes, in order: the list is not **Published** yet; the shortcode ID 
 = Do I have to write the template myself? =
 
 No. Pick a layout from **Start from a template** in the list editor — thumbnail cards, a year archive, a category index, a user directory and more. It copies the markup and styles into the editable Template and Style fields, so you can use it as-is or adjust anything.
+
+= Can I see a list before publishing it? =
+
+Yes - the **Preview** button under the editor renders your current, unsaved settings, and refreshes automatically as you change options. It renders without your theme's stylesheet, so spacing and fonts will differ slightly on the real page.
 
 = Can I display custom fields (including ACF)? =
 
@@ -125,12 +129,13 @@ In your admin: **W4 Post List → Documentation** (template tags reference, exam
 * New: Switching list type with an incompatible template shows an inline warning with a one-click "Replace with the default template" fix.
 * New: The list editor form is protected by a nonce; quick edit, bulk edit and autosave can never touch list options.
 * Improved: "Any" post status now excludes the concrete statuses automatically.
-* New: A once-only review request appears a week after your first published list. One click dismisses it forever.
+* New: A once-only review request appears a week after your first published list. Clicking either button - including "Leave a review" itself - resolves it forever.
 = 2.10.0 =
 * New: Live preview in the list editor - a Preview button renders your current, unsaved settings in an isolated pane, refreshing automatically after option changes. No more publish-and-reload loops while designing a list.
 * Improved: Getting Started guide mentions the preview workflow.
 = 2.9.0 =
 * New: "Start from a template" - pick from 8 ready-made layouts (simple list, thumbnail cards, title & date list, year archive, category index, category index with posts, user directory, authors with posts). Picking one copies editable markup and styles into the Template and Style fields and sets the options it needs, like Group by. Developers can add layouts via the w4pl/starter_templates filter.
+* New: Applying a starter shows a confirmation and opens the Template section automatically, so you immediately see what you got.
 * Improved: Lists using a legacy preset keep working exactly as before; the legacy preset field only appears on those lists.
 * Improved: In-plugin docs updated for the new flow; new FAQ "Do I have to write the template myself?".
 * Fix: Guarded the editor form action URL against missing server variables (CLI contexts).
@@ -186,7 +191,7 @@ In your admin: **W4 Post List → Documentation** (template tags reference, exam
 
 == Upgrade Notice ==
 = 2.11.0 =
-Save-time validation with helpful warnings, editor nonce, list-type-switch protection.
+Biggest update yet: 8 starter templates with one-click apply, live preview in the editor, and save-time validation with helpful warnings.
 = 2.10.0 =
 Live preview in the list editor.
 = 2.9.0 =


### PR DESCRIPTION
## Summary
Docs-only pass before the 2.11.0 release: changelog entries for the two review-driven UX fixes, a live-preview FAQ, a preview mention in the description, and an upgrade notice that headlines the combined three-milestone jump users will actually experience coming from 2.8.0.

## Test plan
- [ ] CI green (text-only change; suite unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)