### PR TITLE
3.0.0 — drop jQuery from the front end

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,12 @@
 == Changelog ==
+= 3.0.0 =
+* Fix: AJAX pagination now works on block themes. It was built on jQuery, which block themes - Twenty Twenty-Four, Twenty Twenty-Five and most modern themes - do not load on the front end, so clicking a page number silently did nothing. Pagination is now plain JavaScript with no dependencies.
+* Improved: Lists no longer print a script tag inside your page. One small shared script loads in the footer, and only on pages where a list actually uses AJAX pagination.
+* Improved: Ctrl-click, Cmd-click and middle-click on a page number now open a new tab, as they should. The old handler hijacked them.
+* Improved: If a page request fails, the list clears its loading state and falls back to a normal page load instead of getting stuck.
+* Fix: Three admin stylesheets and two admin scripts were being registered on every front-end request. They are admin-only now - the plugin adds nothing to your front end unless a list on the page needs it.
+* Dev: register_scripts() is deprecated in favour of register_admin_scripts(); front-end assets are registered by register_frontend_scripts(). The w4pl-ajax-nav handle can be pointed at your own file with wp_deregister_script() + wp_register_script().
+* Note: this is a major version number because the front end no longer depends on jQuery. Your saved lists, templates, styles and settings are untouched, and no template changes are needed.
 = 2.11.0 =
 * New: The editor now catches mistakes at save time - non-numeric values in numeric fields are coerced with a clear warning, unknown template tags get a "did you mean" suggestion, and a template missing its loop tag warns before rendering blank.
 * New: Switching list type with an incompatible template shows an inline warning with a one-click "Replace with the default template" fix.

--- a/assets/js/list-ajax-nav.js
+++ b/assets/js/list-ajax-nav.js
@@ -1,0 +1,124 @@
+/**
+ * AJAX pagination for lists rendered with [nav ajax="1"].
+ *
+ * Replaces the inline jQuery snippet that shipped through 2.x. Block themes do
+ * not enqueue jQuery on the front end, so that snippet threw a ReferenceError
+ * and pagination silently did nothing. This has no dependencies and needs no
+ * per-list inline script: one delegated listener serves every list on the page.
+ *
+ * @package W4_Post_List
+ * @author Shazzad Hossain Khan
+ * @url https://w4dev.com/plugins/w4-post-list
+**/
+(function () {
+	'use strict';
+
+	// Browsers without these keep plain, full-page-reload pagination.
+	if (!window.fetch || !window.DOMParser || !Element.prototype.closest) {
+		return;
+	}
+
+	var LOADING_CLASS = 'w4pl-loading';
+
+	// Monotonic token so a slow response can never overwrite a newer one.
+	var requestId = 0;
+
+	/**
+	 * The list wrapper owning a clicked pagination link, or null when the link
+	 * is not inside an ajax-enabled W4 Post List navigation.
+	 */
+	function getWrapper(link) {
+		var nav = link.closest('.navigation.ajax-navigation');
+		if (!nav) {
+			return null;
+		}
+
+		var wrapper = nav.closest('[id^="w4pl-list-"]');
+		if (!wrapper || !wrapper.id) {
+			return null;
+		}
+
+		return wrapper;
+	}
+
+	/**
+	 * Replace the .w4pl-inner subtree of `wrapper` with the matching subtree of
+	 * the document at `url`. Same contract as the old jQuery .load() call: only
+	 * the inner subtree is swapped, and scripts in the response never run.
+	 */
+	function swapPage(wrapper, url) {
+		var token = ++requestId;
+		wrapper.w4plRequest = token;
+
+		wrapper.classList.add(LOADING_CLASS);
+		wrapper.setAttribute('aria-busy', 'true');
+
+		var clearLoading = function () {
+			wrapper.classList.remove(LOADING_CLASS);
+			wrapper.removeAttribute('aria-busy');
+		};
+
+		window.fetch(url, {
+			credentials: 'same-origin',
+			headers: { 'X-Requested-With': 'XMLHttpRequest' }
+		}).then(function (response) {
+			if (!response.ok) {
+				throw new Error('HTTP ' + response.status);
+			}
+			return response.text();
+		}).then(function (html) {
+			// A newer click on this list already won; drop this response.
+			if (wrapper.w4plRequest !== token) {
+				return;
+			}
+
+			var doc = new DOMParser().parseFromString(html, 'text/html');
+			var fresh = doc.querySelector('[id="' + wrapper.id + '"] .w4pl-inner');
+
+			if (!fresh) {
+				throw new Error('missing fragment');
+			}
+
+			wrapper.innerHTML = fresh.outerHTML;
+			clearLoading();
+		}).catch(function () {
+			if (wrapper.w4plRequest !== token) {
+				return;
+			}
+
+			clearLoading();
+
+			// Never dead-end the visitor: fall back to a normal page load.
+			window.location.href = url;
+		});
+	}
+
+	document.addEventListener('click', function (event) {
+		if (event.defaultPrevented || event.button !== 0) {
+			return;
+		}
+
+		// Let the browser handle open-in-new-tab / new-window / download.
+		if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+			return;
+		}
+
+		var target = event.target;
+		if (!target || !target.closest) {
+			return;
+		}
+
+		var link = target.closest('a.page-numbers');
+		if (!link || !link.href) {
+			return;
+		}
+
+		var wrapper = getWrapper(link);
+		if (!wrapper) {
+			return;
+		}
+
+		event.preventDefault();
+		swapPage(wrapper, link.href);
+	});
+})();

--- a/includes/abstracts/class-list.php
+++ b/includes/abstracts/class-list.php
@@ -140,19 +140,16 @@ abstract class W4PL_List {
 			$use_ajax = isset( $attr['ajax'] ) ? (bool) $attr['ajax'] : false;
 
 			if ( $use_ajax ) {
+				/*
+				 * The `ajax-navigation` class is the whole contract: the
+				 * front-end script finds the owning `#w4pl-list-{id}` wrapper
+				 * from the clicked link and swaps its `.w4pl-inner` subtree.
+				 * One shared script handles every list on the page, so no
+				 * per-list inline JS is emitted any more.
+				 */
 				$class .= ' ajax-navigation';
-				$this->js .= ';(function($){
-					$(document).ready(function(){
-						$(document.body).on("click", "#w4pl-list-' . $this->id . ' .navigation a.page-numbers", function(){
-							var that = $(this), parent = $("#w4pl-list-' . $this->id . '");
-							parent.addClass("w4pl-loading");
-							parent.load( that.attr("href") + " #" + parent.attr("id") + " .w4pl-inner", function(e){
-								parent.removeClass("w4pl-loading");
-							});
-							return false;
-						});
-					});
-				})(jQuery);';
+
+				w4pl_enqueue_ajax_nav_script();
 			}
 
 			$return = '<div class="' . $class . '">' . $return . '</div>';

--- a/includes/class-w4-post-list.php
+++ b/includes/class-w4-post-list.php
@@ -29,7 +29,7 @@ final class W4_Post_List {
 	 *
 	 * @var string
 	 */
-	public $version = '2.11.0';
+	public $version = '3.0.0';
 
 	/**
 	 * This will hold current class instance
@@ -188,8 +188,30 @@ final class W4_Post_List {
 	public function init_hooks() {
 		add_action( 'init', array( $this, 'load_plugin_translations' ) );
 		add_action( 'widgets_init', array( $this, 'widget_init' ) );
-		add_action( 'wp_enqueue_scripts', array( $this, 'register_scripts' ), 2 );
-		add_action( 'admin_enqueue_scripts', array( $this, 'register_scripts' ), 2 );
+		add_action( 'wp_enqueue_scripts', array( $this, 'register_frontend_scripts' ), 2 );
+		add_action( 'admin_enqueue_scripts', array( $this, 'register_admin_scripts' ), 2 );
+	}
+
+	/**
+	 * Register front-end javascripts.
+	 *
+	 * Registration only; W4PL_List::navigation() enqueues on demand when a
+	 * rendered list actually uses [nav ajax="1"]. Registering early lets site
+	 * owners point the handle at their own file (wp_deregister_script() then
+	 * wp_register_script()) or attach script data to it; those changes stick,
+	 * because the render-time wp_enqueue_script() in
+	 * w4pl_enqueue_ajax_nav_script() no-ops for an already-registered handle.
+	 * A bare wp_deregister_script() does not suppress the script - that same
+	 * call re-registers it; suppressing it means not rendering [nav ajax="1"].
+	 */
+	public function register_frontend_scripts() {
+		wp_register_script(
+			'w4pl-ajax-nav',
+			W4PL_URL . 'assets/js/list-ajax-nav.js',
+			array(),
+			w4pl_asset_version(),
+			true
+		);
 	}
 
 	/**
@@ -208,18 +230,22 @@ final class W4_Post_List {
 	}
 
 	/**
-	 * Register stylesheets / javascripts
+	 * Register admin stylesheets / javascripts.
 	 *
-	 * All plugin assets are admin-only, so unminified sources are always
-	 * served; minification buys nothing there.
+	 * Every handle below is enqueued only from the list editor
+	 * (admin/class-admin-list-editor.php) and the documentation page
+	 * (admin/pages/class-admin-page-docs.php), so this runs on
+	 * `admin_enqueue_scripts` alone. Through 2.x it also ran on
+	 * `wp_enqueue_scripts`, registering five unused - and jQuery-dependent -
+	 * handles on every front-end request.
+	 *
+	 * These are admin assets, so unminified sources are always served;
+	 * minification buys nothing there.
+	 *
+	 * @since 3.0.0 Renamed from register_scripts(); no longer runs on the front end.
 	 */
-	public function register_scripts() {
-		$version = W4PL_VERSION;
-
-		// While debugging locally, bypass browser caches.
-		if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) {
-			$version = (string) time();
-		}
+	public function register_admin_scripts() {
+		$version = w4pl_asset_version();
 
 		wp_register_style(
 			'w4pl_form',
@@ -254,5 +280,16 @@ final class W4_Post_List {
 			$version,
 			true
 		);
+	}
+
+	/**
+	 * Register admin stylesheets / javascripts.
+	 *
+	 * Back-compat shim for code calling w4pl()->register_scripts() directly.
+	 *
+	 * @deprecated 3.0.0 Use register_admin_scripts().
+	 */
+	public function register_scripts() {
+		$this->register_admin_scripts();
 	}
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -69,6 +69,53 @@ function w4pl_get_shortcodes() {
 	return apply_filters( 'w4pl/get_shortcodes', $shortcodes );
 }
 
+/**
+ * Version string used for cache busting plugin assets.
+ *
+ * @return string
+ */
+function w4pl_asset_version() {
+	// While debugging locally, bypass browser caches.
+	if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) {
+		return (string) time();
+	}
+
+	return W4PL_VERSION;
+}
+
+/**
+ * Enqueue the front-end AJAX pagination script.
+ *
+ * Called from W4PL_List::navigation() at render time, so the script only
+ * reaches pages where a list actually rendered [nav ajax="1"] links. Passing
+ * the full arguments means the handle self-registers in contexts where
+ * `wp_enqueue_scripts` never fires (REST block renderer, the editor preview),
+ * instead of being silently dropped.
+ *
+ * Safe to call repeatedly: WP_Dependencies keeps one entry per handle, so N
+ * lists on a page still add up to a single script tag.
+ */
+function w4pl_enqueue_ajax_nav_script() {
+	wp_enqueue_script(
+		'w4pl-ajax-nav',
+		W4PL_URL . 'assets/js/list-ajax-nav.js',
+		array(),
+		w4pl_asset_version(),
+		true
+	);
+
+	/*
+	 * A list rendered after wp_print_footer_scripts (wp_footer, priority 20)
+	 * enqueues into a queue nothing will flush any more. Print the tag here
+	 * instead - through 2.x the inline snippet was part of the returned HTML,
+	 * so it always shipped. WP_Scripts marks the handle done, so several late
+	 * lists still emit a single script tag.
+	 */
+	if ( did_action( 'wp_print_footer_scripts' ) ) {
+		wp_print_scripts( 'w4pl-ajax-nav' );
+	}
+}
+
 function w4pl_debug( $var, $exit = false ) {
 	echo '<pre>';
 	print_r( $var );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "w4-post-list",
-	"version": "2.11.0",
+	"version": "3.0.0",
 	"description": "A WordPress Plugin for listing posts in some handy manner.",
 	"main": "Gruntfile.js",
 	"scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: post list, user list, post grid, category list, shortcode
 Requires at least: 5.8
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 2.11.0
+Stable tag: 3.0.0
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -130,6 +130,14 @@ In your admin: **W4 Post List → Documentation** (template tags reference, exam
 
 
 == Changelog ==
+= 3.0.0 =
+* Fix: AJAX pagination now works on block themes. It was built on jQuery, which block themes - Twenty Twenty-Four, Twenty Twenty-Five and most modern themes - do not load on the front end, so clicking a page number silently did nothing. Pagination is now plain JavaScript with no dependencies.
+* Improved: Lists no longer print a script tag inside your page. One small shared script loads in the footer, and only on pages where a list actually uses AJAX pagination.
+* Improved: Ctrl-click, Cmd-click and middle-click on a page number now open a new tab, as they should. The old handler hijacked them.
+* Improved: If a page request fails, the list clears its loading state and falls back to a normal page load instead of getting stuck.
+* Fix: Three admin stylesheets and two admin scripts were being registered on every front-end request. They are admin-only now - the plugin adds nothing to your front end unless a list on the page needs it.
+* Dev: register_scripts() is deprecated in favour of register_admin_scripts(); front-end assets are registered by register_frontend_scripts(). The w4pl-ajax-nav handle can be pointed at your own file with wp_deregister_script() + wp_register_script().
+* Note: this is a major version number because the front end no longer depends on jQuery. Your saved lists, templates, styles and settings are untouched, and no template changes are needed.
 = 2.11.0 =
 * New: The editor now catches mistakes at save time - non-numeric values in numeric fields are coerced with a clear warning, unknown template tags get a "did you mean" suggestion, and a template missing its loop tag warns before rendering blank.
 * New: Switching list type with an incompatible template shows an inline warning with a one-click "Replace with the default template" fix.
@@ -196,6 +204,8 @@ In your admin: **W4 Post List → Documentation** (template tags reference, exam
 [See changelog of all versions](https://raw.githubusercontent.com/w4devInc/w4-post-list/master/CHANGELOG.txt).
 
 == Upgrade Notice ==
+= 3.0.0 =
+AJAX pagination now works on block themes and no longer needs jQuery. Despite the major version number, nothing about your saved lists, templates or settings changes.
 = 2.11.0 =
 Biggest update yet: 8 starter templates with one-click apply, live preview in the editor, and save-time validation with helpful warnings.
 = 2.10.0 =

--- a/tests/AdminAssetsTest.php
+++ b/tests/AdminAssetsTest.php
@@ -1,0 +1,311 @@
+<?php
+/**
+ * Admin-only assets must not be registered on front-end requests.
+ *
+ * Three styles and two scripts exist purely for the list editor and the
+ * documentation page. They were registered on every front-end request as well,
+ * where nothing has ever enqueued them - dead weight on ~2000 sites, and the
+ * last jQuery-dependent registrations the front end carried.
+ *
+ * These tests pin the split both ways: gone from the front end, byte-identical
+ * in wp-admin, with the new front-end AJAX nav script unaffected.
+ *
+ * @package W4_Post_List
+ */
+
+class AdminAssetsTest extends WP_UnitTestCase {
+
+	/**
+	 * Styles registered by register_admin_scripts(): handle => src.
+	 */
+	const ADMIN_STYLES = array(
+		'w4pl_form'                => 'assets/css/form.css',
+		'w4pl_list_editor'         => 'assets/css/list-editor.css',
+		'w4pl-admin-documentation' => 'assets/css/admin-documentation.css',
+	);
+
+	/**
+	 * Scripts registered by register_admin_scripts(): handle => src.
+	 */
+	const ADMIN_SCRIPTS = array(
+		'w4pl_form'        => 'assets/js/form.js',
+		'w4pl_list_editor' => 'assets/js/list-editor.js',
+	);
+
+	const NAV_HANDLE = 'w4pl-ajax-nav';
+
+	public function set_up() {
+		parent::set_up();
+
+		// Asset registries are globals and backupGlobals is off: start clean so
+		// every "registered" assertion describes this test only. Re-creating
+		// them fires wp_default_scripts/styles, so core handles (jquery, ...)
+		// are present exactly as on a real request.
+		$GLOBALS['wp_scripts'] = null;
+		$GLOBALS['wp_styles']  = null;
+
+		wp_set_current_user( 0 );
+	}
+
+	public function tear_down() {
+		$GLOBALS['wp_scripts'] = null;
+		$GLOBALS['wp_styles']  = null;
+
+		parent::tear_down();
+	}
+
+	/* ---------------------------------------------------------------------
+	 * Front end: gone.
+	 * ------------------------------------------------------------------ */
+
+	public function test_admin_only_styles_are_not_registered_on_the_front_end() {
+		do_action( 'wp_enqueue_scripts' );
+
+		foreach ( array_keys( self::ADMIN_STYLES ) as $handle ) {
+			$this->assertFalse(
+				wp_style_is( $handle, 'registered' ),
+				"Style '{$handle}' is admin-only and must not be registered on the front end."
+			);
+		}
+	}
+
+	public function test_admin_only_scripts_are_not_registered_on_the_front_end() {
+		do_action( 'wp_enqueue_scripts' );
+
+		foreach ( array_keys( self::ADMIN_SCRIPTS ) as $handle ) {
+			$this->assertFalse(
+				wp_script_is( $handle, 'registered' ),
+				"Script '{$handle}' is admin-only and must not be registered on the front end."
+			);
+		}
+	}
+
+	/**
+	 * The release theme: after this change the front end registers nothing
+	 * that pulls in jQuery.
+	 */
+	public function test_front_end_registers_no_jquery_dependent_plugin_assets() {
+		do_action( 'wp_enqueue_scripts' );
+
+		foreach ( wp_scripts()->registered as $handle => $script ) {
+			if ( 0 !== strpos( $handle, 'w4pl' ) ) {
+				continue;
+			}
+
+			$this->assertNotContains(
+				'jquery',
+				(array) $script->deps,
+				"Front-end handle '{$handle}' still depends on jQuery."
+			);
+		}
+	}
+
+	/* ---------------------------------------------------------------------
+	 * Admin: unchanged.
+	 * ------------------------------------------------------------------ */
+
+	/**
+	 * Fire admin_enqueue_scripts the way wp-admin does.
+	 *
+	 * A screen must exist first: core's own Site Health callback on this hook
+	 * dereferences get_current_screen().
+	 */
+	private function do_admin_enqueue_scripts() {
+		set_current_screen( 'post.php' );
+
+		do_action( 'admin_enqueue_scripts', 'post.php' );
+	}
+
+	public function test_admin_styles_are_registered_exactly_as_before() {
+		$this->do_admin_enqueue_scripts();
+
+		foreach ( self::ADMIN_STYLES as $handle => $src ) {
+			$this->assertTrue( wp_style_is( $handle, 'registered' ), "Style '{$handle}' must stay registered in admin." );
+
+			$style = wp_styles()->registered[ $handle ];
+
+			$this->assertSame( W4PL_URL . $src, $style->src );
+			$this->assertSame( array(), $style->deps );
+			$this->assertSame( W4PL_VERSION, $style->ver );
+		}
+	}
+
+	public function test_admin_scripts_are_registered_exactly_as_before() {
+		$this->do_admin_enqueue_scripts();
+
+		foreach ( self::ADMIN_SCRIPTS as $handle => $src ) {
+			$this->assertTrue( wp_script_is( $handle, 'registered' ), "Script '{$handle}' must stay registered in admin." );
+
+			$script = wp_scripts()->registered[ $handle ];
+
+			$this->assertSame( W4PL_URL . $src, $script->src );
+			$this->assertSame( array( 'jquery', 'jquery-ui-sortable' ), $script->deps );
+			$this->assertSame( W4PL_VERSION, $script->ver );
+			$this->assertSame( 1, $script->extra['group'], "Script '{$handle}' must stay in the footer." );
+		}
+	}
+
+	/**
+	 * The list editor enqueues by bare handle, which silently no-ops for an
+	 * unregistered handle. Guard the registration those call sites rely on.
+	 */
+	public function test_list_editor_can_enqueue_its_assets_in_admin() {
+		require_once dirname( __DIR__ ) . '/admin/class-admin-list-editor.php';
+
+		$this->do_admin_enqueue_scripts();
+
+		wp_enqueue_style( 'w4pl_form' );
+		wp_enqueue_style( 'w4pl_list_editor' );
+		wp_enqueue_script( 'w4pl_form' );
+		wp_enqueue_script( 'w4pl_list_editor' );
+
+		$this->assertTrue( wp_style_is( 'w4pl_form', 'enqueued' ) );
+		$this->assertTrue( wp_style_is( 'w4pl_list_editor', 'enqueued' ) );
+		$this->assertTrue( wp_script_is( 'w4pl_form', 'enqueued' ) );
+		$this->assertTrue( wp_script_is( 'w4pl_list_editor', 'enqueued' ) );
+	}
+
+	public function test_docs_page_can_enqueue_its_stylesheet_in_admin() {
+		$this->do_admin_enqueue_scripts();
+
+		wp_enqueue_style( 'w4pl-admin-documentation' );
+
+		$this->assertTrue( wp_style_is( 'w4pl-admin-documentation', 'enqueued' ) );
+	}
+
+	/* ---------------------------------------------------------------------
+	 * Interaction with the new front-end script.
+	 * ------------------------------------------------------------------ */
+
+	public function test_ajax_nav_script_is_still_registered_on_the_front_end() {
+		do_action( 'wp_enqueue_scripts' );
+
+		$this->assertTrue( wp_script_is( self::NAV_HANDLE, 'registered' ) );
+		$this->assertSame( array(), wp_scripts()->registered[ self::NAV_HANDLE ]->deps );
+	}
+
+	public function test_rendering_an_ajax_list_on_the_front_end_still_enqueues_the_nav_script() {
+		do_action( 'wp_enqueue_scripts' );
+
+		$this->render_paginated_ajax_list();
+
+		$this->assertTrue( wp_script_is( self::NAV_HANDLE, 'enqueued' ) );
+	}
+
+	/**
+	 * Nothing else may ride along with it.
+	 */
+	public function test_a_front_end_page_with_an_ajax_list_queues_only_the_nav_script() {
+		do_action( 'wp_enqueue_scripts' );
+
+		$this->render_paginated_ajax_list();
+
+		$this->assertSame( array( self::NAV_HANDLE ), $this->plugin_handles( wp_scripts()->queue ) );
+		$this->assertSame( array(), $this->plugin_handles( wp_styles()->queue ) );
+	}
+
+	/* ---------------------------------------------------------------------
+	 * Paths that must not regress.
+	 * ------------------------------------------------------------------ */
+
+	/**
+	 * The block's editor script is registered from blocks.php on `init`, not
+	 * from the admin/front split, so the block editor is untouched.
+	 */
+	public function test_block_editor_script_registration_is_untouched() {
+		$block = WP_Block_Type_Registry::get_instance()->get_registered( 'w4-post-list/postlist' );
+
+		$this->assertInstanceOf( 'WP_Block_Type', $block );
+
+		$handles = property_exists( $block, 'editor_script_handles' )
+			? (array) $block->editor_script_handles
+			: array( $block->editor_script );
+
+		$this->assertContains( 'w4pl_block', $handles );
+		$this->assertSame( 'w4pl_render_block_postlist', $block->render_callback );
+	}
+
+	/**
+	 * The preview endpoint runs in admin-ajax.php, where neither enqueue hook
+	 * fires. It never needed the admin handles and must keep working without
+	 * them - including enqueueing the nav script by self-registration.
+	 */
+	public function test_preview_render_path_needs_no_registered_assets() {
+		require_once dirname( __DIR__ ) . '/admin/class-admin-lists-metaboxes.php';
+		require_once dirname( __DIR__ ) . '/admin/class-admin-preview.php';
+
+		// Enough posts to paginate; the fodder post is created last so the
+		// newest-first first page is the one asserted on below.
+		for ( $i = 0; $i < 5; $i++ ) {
+			$this->factory->post->create( array( 'post_title' => 'Filler ' . $i ) );
+		}
+		$this->factory->post->create( array( 'post_title' => 'Preview fodder' ) );
+
+		// Deliberately fire neither wp_enqueue_scripts nor admin_enqueue_scripts.
+		$this->assertFalse( wp_script_is( self::NAV_HANDLE, 'registered' ), 'Sanity: nothing pre-registered the handle.' );
+
+		$html = W4PL_Admin_Preview::render_preview(
+			array(
+				'id'             => 424242,
+				'list_type'      => 'posts',
+				'post_type'      => array( 'post' ),
+				'posts_per_page' => 2,
+				'template'       => '<ul>[posts]<li>[post_title]</li>[/posts]</ul>[nav type="plain" ajax="1"]',
+			)
+		);
+
+		$this->assertStringContainsString( 'Preview fodder', $html );
+		$this->assertStringContainsString( 'ajax-navigation', $html, 'Sanity: the preview really rendered ajax nav.' );
+		$this->assertTrue( wp_script_is( self::NAV_HANDLE, 'enqueued' ), 'The nav script must self-register where no enqueue hook fires.' );
+		$this->assertFalse( wp_style_is( 'w4pl_form', 'registered' ) );
+	}
+
+	/* ------------------------------------------------------------------ */
+
+	/**
+	 * Keep only this plugin's handles; core queues its own on every request.
+	 *
+	 * @param array $handles Enqueued handles.
+	 * @return array
+	 */
+	private function plugin_handles( array $handles ) {
+		return array_values(
+			array_filter(
+				$handles,
+				function ( $handle ) {
+					return 0 === strpos( $handle, 'w4pl' );
+				}
+			)
+		);
+	}
+
+	/**
+	 * Render a 3-page ajax-paginated list through the shortcode pipeline.
+	 *
+	 * @return string
+	 */
+	private function render_paginated_ajax_list() {
+		for ( $i = 0; $i < 6; $i++ ) {
+			$this->factory->post->create( array( 'post_title' => 'Item ' . $i ) );
+		}
+
+		$list_id = $this->factory->post->create(
+			array(
+				'post_type'   => 'w4pl',
+				'post_status' => 'publish',
+			)
+		);
+		update_post_meta(
+			$list_id,
+			'_w4pl',
+			array(
+				'list_type'      => 'posts',
+				'post_type'      => array( 'post' ),
+				'posts_per_page' => 2,
+				'template'       => '<ul>[posts]<li>[post_title]</li>[/posts]</ul>[nav type="plain" ajax="1"]',
+			)
+		);
+
+		return do_shortcode( '[postlist id="' . $list_id . '"]' );
+	}
+}

--- a/tests/AjaxNavTest.php
+++ b/tests/AjaxNavTest.php
@@ -1,0 +1,317 @@
+<?php
+/**
+ * AJAX pagination must work without jQuery.
+ *
+ * Block themes (Twenty Twenty-Four / Twenty Twenty-Five and most 2026 themes)
+ * do not enqueue jQuery on the front end, so the inline jQuery snippet that
+ * shipped through 2.x threw a ReferenceError and AJAX pagination silently did
+ * nothing. These tests pin the replacement: a registered, dependency-free
+ * front-end script enqueued only when a rendered list actually uses [nav
+ * ajax="1"], and zero inline JS in the rendered markup.
+ *
+ * PHPUnit cannot execute the browser half of this feature. The click / swap /
+ * failure behaviours live in tests/MANUAL-QA.md.
+ *
+ * @package W4_Post_List
+ */
+
+require_once __DIR__ . '/class-w4pl-snapshot-testcase.php';
+
+class AjaxNavTest extends W4PL_Snapshot_TestCase {
+
+	const HANDLE = 'w4pl-ajax-nav';
+
+	/**
+	 * Template with a 3-page ajax pagination (6 fixture posts / 2 per page).
+	 */
+	const AJAX_TEMPLATE = '<ul>[posts]<li>[post_title]</li>[/posts]</ul>[nav type="plain" ajax="1"]';
+
+	/**
+	 * Same template, plain pagination.
+	 */
+	const PLAIN_TEMPLATE = '<ul>[posts]<li>[post_title]</li>[/posts]</ul>[nav type="plain"]';
+
+	public function set_up() {
+		parent::set_up();
+
+		// Asset registries are globals and backupGlobals is off: start clean so
+		// "registered" / "enqueued" assertions describe this test only.
+		$GLOBALS['wp_scripts'] = null;
+		$GLOBALS['wp_styles']  = null;
+
+		// Render as a visitor; an admin-only notice would pollute assertions.
+		wp_set_current_user( 0 );
+	}
+
+	public function tear_down() {
+		$GLOBALS['wp_scripts'] = null;
+		$GLOBALS['wp_styles']  = null;
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Base options for a paginated posts list.
+	 *
+	 * @param string $template Template string.
+	 * @return array
+	 */
+	private function paginated_options( $template ) {
+		return array(
+			'list_type'      => 'posts',
+			'post_type'      => array( 'post' ),
+			'posts_per_page' => 2,
+			'orderby'        => 'post_date',
+			'order'          => 'DESC',
+			'template'       => $template,
+		);
+	}
+
+	/**
+	 * Same path as render_list(), but keeps the list id.
+	 *
+	 * @param array $options List options.
+	 * @return int
+	 */
+	private function make_list( array $options ) {
+		$list_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'w4pl',
+				'post_title'  => 'Ajax nav list',
+				'post_status' => 'publish',
+			)
+		);
+		update_post_meta( $list_id, '_w4pl', $options );
+
+		return $list_id;
+	}
+
+	/**
+	 * Build a list object directly, bypassing the CPT, so the accumulated
+	 * $js property can be asserted on.
+	 *
+	 * @param array $options List options.
+	 * @return W4PL_List
+	 */
+	private function build_list( array $options ) {
+		$options['id'] = $this->make_list( $options );
+
+		return W4PL_List_Factory::get_list( apply_filters( 'w4pl/pre_get_options', $options ) );
+	}
+
+	/* ---------------------------------------------------------------------
+	 * No inline jQuery.
+	 * ------------------------------------------------------------------ */
+
+	public function test_ajax_nav_accumulates_no_inline_js() {
+		$list = $this->build_list( $this->paginated_options( self::AJAX_TEMPLATE ) );
+		$list->get_html();
+
+		$this->assertSame(
+			'',
+			$list->js,
+			'AJAX navigation must not push anything into the inline JS channel.'
+		);
+	}
+
+	public function test_ajax_nav_output_contains_no_jquery_and_no_script_tag() {
+		$html = $this->render_list( $this->paginated_options( self::AJAX_TEMPLATE ) );
+
+		$this->assertStringContainsString( 'ajax-navigation', $html, 'Sanity: the list really did render ajax nav.' );
+		$this->assertStringNotContainsString( 'jQuery', $html, 'Block themes do not load jQuery on the front end.' );
+		$this->assertStringNotContainsString( '<script', $html, 'AJAX navigation must not emit per-list inline JS.' );
+	}
+
+	/**
+	 * Guard rail against over-deleting: the shared inline-JS channel still
+	 * carries the user's own per-list JS option.
+	 */
+	public function test_custom_per_list_js_option_still_renders() {
+		$options       = $this->paginated_options( self::AJAX_TEMPLATE );
+		$options['js'] = 'window.w4plCustomHook = 1;';
+
+		$html = $this->render_list( $options );
+
+		$this->assertStringContainsString( 'window.w4plCustomHook = 1;', $html );
+		$this->assertMatchesRegularExpression( '/<script id="w4pl-js-\d+"/', $html );
+	}
+
+	/* ---------------------------------------------------------------------
+	 * Markup contract the script keys off.
+	 * ------------------------------------------------------------------ */
+
+	public function test_ajax_nav_markup_carries_every_hook_the_script_needs() {
+		$list_id = $this->make_list( $this->paginated_options( self::AJAX_TEMPLATE ) );
+		$html    = do_shortcode( '[postlist id="' . $list_id . '"]' );
+
+		// 1. The wrapper the script swaps into, addressable from a clicked link.
+		$this->assertStringContainsString( 'id="w4pl-list-' . $list_id . '"', $html );
+		// 2. The subtree that gets replaced.
+		$this->assertStringContainsString( 'class="w4pl-inner"', $html );
+		// 3. The opt-in marker that distinguishes ajax nav from plain nav.
+		$this->assertStringContainsString( 'class="navigation ajax-navigation"', $html );
+		// 4. The links, carrying this list's own page parameter.
+		$this->assertStringContainsString( 'class="page-numbers" href="', $html );
+		$this->assertStringContainsString( 'page' . $list_id . '=2', $html );
+	}
+
+	public function test_plain_nav_is_not_marked_as_ajax() {
+		$html = $this->render_list( $this->paginated_options( self::PLAIN_TEMPLATE ) );
+
+		$this->assertStringContainsString( 'class="navigation"', $html );
+		$this->assertStringNotContainsString( 'ajax-navigation', $html );
+	}
+
+	/* ---------------------------------------------------------------------
+	 * Asset registration / conditional enqueue.
+	 * ------------------------------------------------------------------ */
+
+	public function test_script_is_registered_on_the_front_end() {
+		do_action( 'wp_enqueue_scripts' );
+
+		$this->assertTrue( wp_script_is( self::HANDLE, 'registered' ) );
+	}
+
+	public function test_registered_script_has_no_dependencies_and_loads_in_the_footer() {
+		do_action( 'wp_enqueue_scripts' );
+
+		$script = wp_scripts()->registered[ self::HANDLE ];
+
+		$this->assertSame( array(), $script->deps, 'Vanilla JS: block themes do not load jQuery.' );
+		$this->assertNotEmpty( $script->ver, 'A version is needed for cache busting.' );
+		$this->assertSame( 1, $script->extra['group'], 'The script must print in the footer.' );
+	}
+
+	public function test_registered_script_points_at_a_file_that_exists() {
+		do_action( 'wp_enqueue_scripts' );
+
+		$src  = wp_scripts()->registered[ self::HANDLE ]->src;
+		$path = str_replace( W4PL_URL, trailingslashit( W4PL_DIR ), $src );
+
+		$this->assertFileExists( $path, 'A registered but missing script 404s silently.' );
+	}
+
+	public function test_rendering_an_ajax_list_enqueues_the_script() {
+		$this->render_list( $this->paginated_options( self::AJAX_TEMPLATE ) );
+
+		$this->assertTrue( wp_script_is( self::HANDLE, 'enqueued' ) );
+	}
+
+	/**
+	 * Pins both halves of the register-then-enqueue split on a page with no
+	 * list at all. Without this, collapsing wp_register_script() into
+	 * wp_enqueue_script() in register_frontend_scripts() - a plausible
+	 * "simplification" - would ship the script on every front-end request and
+	 * the whole suite would stay green.
+	 */
+	public function test_a_front_end_page_with_no_ajax_list_registers_but_does_not_enqueue_the_script() {
+		do_action( 'wp_enqueue_scripts' );
+
+		$this->assertTrue( wp_script_is( self::HANDLE, 'registered' ) );
+		$this->assertFalse( wp_script_is( self::HANDLE, 'enqueued' ) );
+	}
+
+	public function test_rendering_a_plain_nav_list_does_not_enqueue_the_script() {
+		$this->render_list( $this->paginated_options( self::PLAIN_TEMPLATE ) );
+
+		$this->assertFalse( wp_script_is( self::HANDLE, 'enqueued' ) );
+	}
+
+	public function test_rendering_a_list_with_no_nav_at_all_does_not_enqueue_the_script() {
+		$this->render_list(
+			array(
+				'list_type'      => 'posts',
+				'post_type'      => array( 'post' ),
+				'posts_per_page' => 10,
+				'template'       => '<ul>[posts]<li>[post_title]</li>[/posts]</ul>',
+			)
+		);
+
+		$this->assertFalse( wp_script_is( self::HANDLE, 'enqueued' ) );
+	}
+
+	/**
+	 * With no results there are no pagination links, so there is nothing for
+	 * the script to bind to and it must stay out of the page.
+	 */
+	public function test_ajax_list_with_no_results_does_not_enqueue_the_script() {
+		$this->render_list(
+			array(
+				'list_type'      => 'posts',
+				'post_type'      => array( 'post' ),
+				'post__in'       => '999999',
+				'posts_per_page' => 2,
+				'template'       => self::AJAX_TEMPLATE,
+			)
+		);
+
+		$this->assertFalse( wp_script_is( self::HANDLE, 'enqueued' ) );
+	}
+
+	/**
+	 * Through 2.x the inline IIFE was part of the returned HTML, so it shipped
+	 * whenever the list rendered. An enqueue is only honoured while something
+	 * still flushes the queue: a list rendered after wp_print_footer_scripts
+	 * (wp_footer, priority 20) would otherwise emit no script at all.
+	 *
+	 * did_action() counters accumulate across tests in one process, so fire the
+	 * hook explicitly rather than relying on a fresh wp_footer().
+	 */
+	public function test_list_rendered_after_footer_scripts_still_ships_the_script() {
+		$list_id = $this->make_list( $this->paginated_options( self::AJAX_TEMPLATE ) );
+
+		ob_start();
+		do_action( 'wp_print_footer_scripts' );
+		$html = do_shortcode( '[postlist id="' . $list_id . '"]' );
+		$out  = ob_get_clean();
+
+		$this->assertStringContainsString( 'ajax-navigation', $html, 'Sanity: the list really did render ajax nav.' );
+		$this->assertStringContainsString( 'list-ajax-nav.js', $out . $html, 'A late-rendered list must still print the script tag.' );
+	}
+
+	/* ---------------------------------------------------------------------
+	 * N lists on one page.
+	 * ------------------------------------------------------------------ */
+
+	public function test_two_ajax_lists_share_one_script_and_keep_independent_page_params() {
+		$id_a = $this->make_list( $this->paginated_options( self::AJAX_TEMPLATE ) );
+		$id_b = $this->make_list( $this->paginated_options( self::AJAX_TEMPLATE ) );
+
+		$html = do_shortcode( '[postlist id="' . $id_a . '"]' ) . do_shortcode( '[postlist id="' . $id_b . '"]' );
+
+		$this->assertNotSame( $id_a, $id_b );
+		$this->assertStringContainsString( 'page' . $id_a . '=2', $html );
+		$this->assertStringContainsString( 'page' . $id_b . '=2', $html );
+		$this->assertStringNotContainsString( '<script', $html, 'No per-list inline JS: one shared script serves N lists.' );
+
+		// One handle, enqueued once, however many lists are on the page.
+		$this->assertTrue( wp_script_is( self::HANDLE, 'enqueued' ) );
+		$this->assertCount( 1, wp_scripts()->queue );
+	}
+
+	/**
+	 * The server half of ajax pagination: a deep link to page 2 must render
+	 * page 2 without any JS involved.
+	 */
+	public function test_deep_link_to_page_two_renders_page_two_server_side() {
+		$list_id                       = $this->make_list( $this->paginated_options( self::AJAX_TEMPLATE ) );
+		$_REQUEST[ 'page' . $list_id ] = 2;
+
+		$html = do_shortcode( '[postlist id="' . $list_id . '"]' );
+
+		unset( $_REQUEST[ 'page' . $list_id ] );
+
+		$this->assertStringContainsString( 'Year in review', $html, 'Page 2 item.' );
+		$this->assertStringNotContainsString( 'Spring cleaning tips', $html, 'Page 1 item.' );
+	}
+
+	/* ---------------------------------------------------------------------
+	 * Characterization snapshot.
+	 * ------------------------------------------------------------------ */
+
+	public function test_posts_pagination_ajax_snapshot() {
+		$html = $this->render_list( $this->paginated_options( self::AJAX_TEMPLATE ) );
+
+		$this->assertMatchesHtmlSnapshot( 'posts-pagination-ajax', $html );
+	}
+}

--- a/tests/MANUAL-QA.md
+++ b/tests/MANUAL-QA.md
@@ -1,8 +1,69 @@
-# Manual QA checklist — list editor JS
+# Manual QA checklist — browser JS
 
-Run before every release that touches `assets/js/list-editor.js` or the editor
-form. The automated suite cannot cover browser behavior; this list can be done
-in ~5 minutes on the docker dev site.
+Run before every release that touches `assets/js/list-editor.js`, the editor
+form, or `assets/js/list-ajax-nav.js`. The automated suite cannot cover browser
+behavior; this list can be done in ~10 minutes on the docker dev site.
+
+## Front-end AJAX pagination (M12)
+
+PHPUnit covers the server side only — that no inline jQuery is emitted, that the
+`w4pl-ajax-nav` handle registers and enqueues exactly when a rendered list uses
+`[nav ajax="1"]`, and that the wrapper markup carries the hooks the script keys
+off. **Everything below is browser-only and is not covered by any test.**
+
+Fixture: a posts list, Items per page 2 (so 3+ pages), template
+`<ul>[posts]<li>[post_title]</li>[/posts]</ul>[nav type="plain" ajax="1"]`.
+
+Test on a **block theme (Twenty Twenty-Five)** first — block themes do not
+enqueue jQuery on the front end, which is the bug this replaces — then repeat
+the first three items on a classic theme (Twenty Twenty-One).
+
+- [ ] Click "2": the items swap in place, no full page reload, no console errors
+- [ ] View source: **no inline `<script>` inside the list**, and `list-ajax-nav.js`
+      is present in the footer (not 404ing)
+- [ ] Load a page with **no** ajax list on it: `list-ajax-nav.js` is absent entirely
+      (also covered by PHPUnit — `AjaxNavTest::test_a_front_end_page_with_no_ajax_list_registers_but_does_not_enqueue_the_script`)
+- [ ] List rendered **late**, after `wp_footer` priority 20 (e.g. a snippet plugin doing
+      `add_action('wp_footer', fn() => echo do_shortcode('[postlist id="N"]'), 30)`):
+      `list-ajax-nav.js` still ships, because the enqueue prints the tag directly once
+      `wp_print_footer_scripts` has already run
+- [ ] Loading state: `.w4pl-loading` is on `#w4pl-list-<ID>` during the fetch and
+      cleared afterwards (add a temporary CSS rule to see it)
+- [ ] Paginate twice in a row: the nav inside the swapped-in markup still works
+      (the listener is delegated, so it survives the swap)
+- [ ] **Two ajax lists on one page**: paging one leaves the other untouched, and
+      `list-ajax-nav.js` is loaded exactly once
+- [ ] Non-ajax list (`[nav type="plain"]`) still does a normal full-page navigation
+- [ ] JS disabled: page links still work as plain hrefs (progressive enhancement)
+- [ ] Ctrl/Cmd-click and middle-click a page link: opens in a new tab as normal
+      (a deliberate improvement over the 2.x jQuery handler, which hijacked these)
+- [ ] Network failure mid-fetch (devtools → offline, then click "2"): the loading
+      class clears and the browser falls through to a normal page load — no dead
+      end, no unhandled promise rejection
+- [ ] Reload / deep-link `?page<ID>=2` in a fresh tab: the server renders page 2
+- [ ] Page served from a full-page cache / CDN: first click still works (no nonce
+      in the URL, so cached HTML is fine)
+- [ ] Admin **Live preview** pane with an ajax-nav list: renders with no
+      `jQuery is not defined` error in the console (the 2.x snippet threw there)
+
+## Front-end asset footprint (M12)
+
+Through 2.x, three admin stylesheets and two admin scripts were registered on
+every front-end request. They were never enqueued there, so nothing should
+change visually — but the admin side must be re-checked, because the same
+method now runs on `admin_enqueue_scripts` only.
+
+- [ ] View source on any front-end page: no `form.css`, `list-editor.css`,
+      `admin-documentation.css`, `form.js` or `list-editor.js` tags
+- [ ] Same page: **no `jquery.min.js` loaded on the plugin's account** on a block
+      theme (a classic theme may still load it for its own reasons)
+- [ ] Front end with an ajax list still looks and behaves exactly as before
+- [ ] List editor screen (`w4pl` → edit): CSS/JS still load — form styling intact,
+      CodeMirror, sortable rows, tag inserter and preview all still work
+- [ ] Documentation page (Lists → Documentation): stylesheet still loads, page is
+      not unstyled
+- [ ] Block editor: insert/edit the W4 Post List block, list picker works and the
+      server-side render preview shows the list
 
 ## CodeMirror
 

--- a/tests/class-w4pl-snapshot-testcase.php
+++ b/tests/class-w4pl-snapshot-testcase.php
@@ -21,6 +21,12 @@ abstract class W4PL_Snapshot_TestCase extends WP_UnitTestCase {
 	protected static $post_ids = array();
 
 	public static function wpSetUpBeforeClass( $factory ) {
+		// The statics are declared once on this abstract base, so every
+		// subclass shares them. Without this reset $post_ids accumulates
+		// across classes and index 0 points at a fixture the previous class's
+		// teardown already deleted.
+		self::$post_ids = array();
+
 		self::$cat_alpha = $factory->term->create(
 			array(
 				'taxonomy' => 'category',

--- a/tests/snapshots/posts-pagination-ajax.html
+++ b/tests/snapshots/posts-pagination-ajax.html
@@ -1,0 +1,10 @@
+<!--W4PL_List_{ID}-->
+<div id="w4pl-list-{ID}" class="w4pl">
+	<div id="w4pl-inner-{ID}" class="w4pl-inner">
+		<ul><li>Spring cleaning tips</li><li>Winter release notes</li></ul><div class="navigation ajax-navigation"><span aria-current="page" class="page-numbers current">1</span>
+<a class="page-numbers" href="http://example.org/?page{ID}=2">2</a>
+<a class="page-numbers" href="http://example.org/?page{ID}=3">3</a>
+<a class="next page-numbers" href="http://example.org/?page{ID}=2">Next</a></div>
+	</div><!--#w4pl-inner-{ID}-->
+</div><!--#w4pl-{ID}-->
+<!--END_W4PL_List_{ID}-->

--- a/w4-post-list.php
+++ b/w4-post-list.php
@@ -3,7 +3,7 @@
  * Plugin Name: W4 Post List
  * Plugin URI: https://w4dev.com/plugins/w4-post-list
  * Description: Create lists of posts, terms and users — grouped archives, taxonomy indexes and user directories — placed anywhere with the block, [postlist] shortcode or widget.
- * Version: 2.11.0
+ * Version: 3.0.0
  * Requires at least: 5.8
  * Requires PHP: 7.4
  * Author: Shazzad Hossain Khan


### PR DESCRIPTION
## Summary

AJAX pagination was an inline jQuery IIFE emitted into the page per list. Block themes — Twenty Twenty-Four, Twenty Twenty-Five and most modern themes — do not enqueue jQuery on the front end, so it threw a `ReferenceError` and pagination silently did nothing. No console-visible clue in the markup, so it just looked like the feature didn't work.

- **New `assets/js/list-ajax-nav.js`** — no dependencies, `fetch` + `DOMParser`, one delegated listener serving every list on the page, a monotonic request token so a slow response can't overwrite a newer click, and a fall-through to normal navigation on failure rather than a dead end.
- **Enqueued at render time**, only when a list actually renders `[nav ajax="1"]`. When a list renders *after* `wp_print_footer_scripts` (snippet plugins hooking `wp_footer` at a late priority), the tag is printed directly — through 2.x the inline snippet was part of the returned HTML, so it always shipped regardless of timing.
- **`register_scripts()` split** into `register_frontend_scripts()` and `register_admin_scripts()`. Three admin stylesheets and two admin scripts were registered on every front-end request and only ever enqueued in admin. `register_scripts()` remains as a deprecated shim.
- **29 new tests** (`AjaxNavTest`, `AdminAssetsTest`) covering the negative cases too — script *not* enqueued when no ajax list is present, admin handles still registered exactly as before, block editor and preview paths untouched. Plus a new `posts-pagination-ajax` snapshot.
- Fixed a latent test-infra bug: `$post_ids` statics on the shared snapshot base class accumulated across test classes.

Why 3.0.0: the front end no longer depends on jQuery. Nothing about `_w4pl` storage, the template parser, or any saved list changes — the upgrade notice says so explicitly.

**One intentional behaviour change:** Ctrl-click, Cmd-click and middle-click on a page link now open a new tab. The 2.x handler hijacked them.

## Test plan

Automated (verified locally, PHP 8.2 / WP 7.0.2):

- [x] `OK (113 tests, 431 assertions)` — up from 84 / 349
- [x] Every pre-existing snapshot byte-identical; only a new one added
- [x] `phpcs` on the three changed PHP files: 41 errors / 25 warnings vs a 41 / 26 baseline — no new violations
- [x] CI green on PHP 7.4 and 8.2

Browser checks — `tests/MANUAL-QA.md` has the full list, these are the ones that matter:

- [x] Twenty Twenty-Five: click page 2, items swap with no reload and no console error
- [x] View source: no inline `<script>` in the list; `list-ajax-nav.js` in the footer
- [x] Page with no ajax list: `list-ajax-nav.js` absent entirely
- [x] Two ajax lists on one page paginate independently; script loads once
- [x] Paginate twice in a row (listener survives the swap)
- [x] Devtools offline → click a page link: loading state clears, falls back to a normal load
- [x] Twenty Twenty-One (classic, has jQuery): unchanged behaviour
- [x] Admin: list editor CSS/JS, CodeMirror, tag inserter, live preview, docs page all still load

🤖 Generated with [Claude Code](https://claude.com/claude-code)